### PR TITLE
Enable webui in content layer.

### DIFF
--- a/common/content_client.cc
+++ b/common/content_client.cc
@@ -46,4 +46,9 @@ gfx::Image& ContentClient::GetNativeImageNamed(int resource_id) const {
       resource_id);
 }
 
+base::RefCountedStaticMemory* ContentClient::GetDataResourceBytes(
+      int resource_id) const {
+  return ResourceBundle::GetSharedInstance().LoadDataResourceBytes(resource_id);
+}
+
 }  // namespace brightray

--- a/common/content_client.h
+++ b/common/content_client.h
@@ -22,6 +22,8 @@ class ContentClient : public content::ContentClient {
   base::StringPiece GetDataResource(int resource_id,
                                     ui::ScaleFactor) const override;
   gfx::Image& GetNativeImageNamed(int resource_id) const override;
+  base::RefCountedStaticMemory* GetDataResourceBytes(
+      int resource_id) const override;
 
   DISALLOW_COPY_AND_ASSIGN(ContentClient);
 };


### PR DESCRIPTION
This patch will allow `brightray` users(AtomShell) to access some Chrome's webuis, such as chrome://gpu, chrome://tracing. @zcbenz PTAL.

Below is a screenshot with `window.location.href="chrome://gpu"`

![image](https://cloud.githubusercontent.com/assets/2557445/6884743/571188a2-d632-11e4-883b-da4add742b5c.png)
