### PR TITLE
detecting focus on devtools webcontents

### DIFF
--- a/browser/inspectable_web_contents_delegate.h
+++ b/browser/inspectable_web_contents_delegate.h
@@ -19,6 +19,7 @@ class InspectableWebContentsDelegate {
       const std::string& url, const std::string& content, bool save_as) {}
   virtual void DevToolsAppendToFile(
       const std::string& url, const std::string& content) {}
+  virtual void DevToolsFocused() {}
 
 #if defined(USE_X11)
   // Called when creating devtools window.

--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -241,6 +241,12 @@ void InspectableWebContentsImpl::AppendToFile(
     delegate_->DevToolsAppendToFile(url, content);
 }
 
+void InspectableWebContentsImpl::WebContentsFocused(
+    content::WebContents* contents) {
+  if (delegate_)
+    delegate_->DevToolsFocused();
+}
+
 void InspectableWebContentsImpl::RequestFileSystems() {
     devtools_web_contents()->GetMainFrame()->ExecuteJavaScript(
         base::ASCIIToUTF16("DevToolsAPI.fileSystemsLoaded([])"));

--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -127,6 +127,7 @@ class InspectableWebContentsImpl :
   void HandleKeyboardEvent(
       content::WebContents*, const content::NativeWebKeyboardEvent&) override;
   void CloseContents(content::WebContents* source) override;
+  void WebContentsFocused(content::WebContents* contents) override;
 
   scoped_ptr<content::WebContents> web_contents_;
   scoped_ptr<content::WebContents> devtools_web_contents_;


### PR DESCRIPTION
Is there a better way to communicate the event ?