### PR TITLE
Ubuntu notification improvements

### DIFF
--- a/browser/linux/notification_presenter_linux.cc
+++ b/browser/linux/notification_presenter_linux.cc
@@ -27,7 +27,7 @@ static bool UnityIsRunning() {
   }
 
   struct DBusError err;
-  struct DBusConnection* bus;
+  struct DBusConnection* bus = NULL;
 
   dbus_error_init(&err);
   
@@ -35,6 +35,7 @@ static bool UnityIsRunning() {
   if (dbus_error_is_set(&err)) {
     g_debug("Failed to get Session Bus reference");
     unity_result = false;
+    dbus_error_free(&err);
 
     goto out;
   }
@@ -43,9 +44,12 @@ static bool UnityIsRunning() {
 
   if (dbus_error_is_set(&err)) {
     unity_result = false;
+    dbus_error_free(&err);
   }
 
 out:
+  if (bus) dbus_connection_unref(bus);
+
   unity_has_result = true;
   return unity_result;
 }
@@ -110,6 +114,7 @@ void NotificationPresenterLinux::ShowNotification(
 
   notify_notification_set_image_from_pixbuf(notification, pixbuf);
   notify_notification_set_timeout(notification, NOTIFY_EXPIRES_DEFAULT);
+  g_object_unref(pixbuf);
 
   GError* error = nullptr;
   notify_notification_show(notification, &error);

--- a/browser/linux/notification_presenter_linux.cc
+++ b/browser/linux/notification_presenter_linux.cc
@@ -52,6 +52,7 @@ NotificationPresenterLinux::~NotificationPresenterLinux() {
 
 void NotificationPresenterLinux::ShowNotification(
     const content::PlatformNotificationData& data,
+    const SkBitmap& icon,
     scoped_ptr<content::DesktopNotificationDelegate> delegate_ptr,
     base::Closure* cancel_callback) {
   std::string title = base::UTF16ToUTF8(data.title);

--- a/browser/linux/notification_presenter_linux.h
+++ b/browser/linux/notification_presenter_linux.h
@@ -27,6 +27,7 @@ class NotificationPresenterLinux : public NotificationPresenter {
   // NotificationPresenter:
   void ShowNotification(
       const content::PlatformNotificationData&,
+      const SkBitmap& icon,
       scoped_ptr<content::DesktopNotificationDelegate> delegate,
       base::Closure* cancel_callback) override;
 

--- a/browser/notification_presenter.h
+++ b/browser/notification_presenter.h
@@ -4,6 +4,8 @@
 #include "base/callback_forward.h"
 #include "base/memory/scoped_ptr.h"
 
+class SkBitmap;
+
 namespace content {
 class DesktopNotificationDelegate;
 struct PlatformNotificationData;
@@ -19,6 +21,7 @@ class NotificationPresenter {
 
   virtual void ShowNotification(
       const content::PlatformNotificationData&,
+      const SkBitmap& icon,
       scoped_ptr<content::DesktopNotificationDelegate> delegate,
       base::Closure* cancel_callback) = 0;
 };

--- a/browser/notification_presenter_mac.h
+++ b/browser/notification_presenter_mac.h
@@ -23,6 +23,7 @@ class NotificationPresenterMac : public NotificationPresenter {
   // NotificationPresenter:
   void ShowNotification(
       const content::PlatformNotificationData&,
+      const SkBitmap& icon,
       scoped_ptr<content::DesktopNotificationDelegate> delegate,
       base::Closure* cancel_callback) override;
 

--- a/browser/notification_presenter_mac.mm
+++ b/browser/notification_presenter_mac.mm
@@ -41,6 +41,7 @@ NotificationPresenterMac::~NotificationPresenterMac() {
 
 void NotificationPresenterMac::ShowNotification(
     const content::PlatformNotificationData& data,
+    const SkBitmap& icon,
     scoped_ptr<content::DesktopNotificationDelegate> delegate,
     base::Closure* cancel_callback) {
   auto notification = [[NSUserNotification alloc] init];

--- a/browser/platform_notification_service_impl.cc
+++ b/browser/platform_notification_service_impl.cc
@@ -44,7 +44,7 @@ void PlatformNotificationServiceImpl::DisplayNotification(
     base::Closure* cancel_callback) {
   auto presenter = notification_presenter();
   if (presenter)
-    presenter->ShowNotification(notification_data, delegate.Pass(), cancel_callback);
+    presenter->ShowNotification(notification_data, icon, delegate.Pass(), cancel_callback);
 }
 
 void PlatformNotificationServiceImpl::DisplayPersistentNotification(


### PR DESCRIPTION
This PR fixes an issue on Ubuntu where HTML5 notifications would show as modal message boxes. From https://wiki.ubuntu.com/NotificationDevelopmentGuidelines#If_a_notification_is_showing_up_as_an_alert_box:

> Because notification bubbles float on top of all other windows, and usually appear without warning, Notify OSD allows click-through. Hovering over a bubble makes it transparent, and you can click — or drag to or from — anything underneath the bubble. [...] So Notify OSD bubbles cannot be clicked on themselves, nor can they contain buttons that can be clicked: in the terminology of the Desktop Notifications Specification, they do not accept actions. 

This PR also enables you to set the Icon on Linux notifications (this is not possible on OS X, so we no-op it).

## TODO:

- [x] Verify on Ubuntu
- [x] Verify on Fedora
- [x] Make sure OS X isn't busted
- [x] Fix detection of libindicate to not require libindicate-dev

Also, I would like to dedicate this PR to @carlosmn, without whom I would have never found that random Wiki page