### PR TITLE
Explicitly create HttpAuthHandlerFactory to enable NTLM / Kerberos authentication

### DIFF
--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -21,7 +21,6 @@
 #include "net/dns/mapped_host_resolver.h"
 #include "net/http/http_auth_handler_factory.h"
 #include "net/http/http_server_properties_impl.h"
-#include "net/http/url_security_manager.h"
 #include "net/proxy/dhcp_proxy_script_fetcher_factory.h"
 #include "net/proxy/proxy_config_service.h"
 #include "net/proxy/proxy_script_fetcher_impl.h"
@@ -120,6 +119,7 @@ URLRequestContextGetter::URLRequestContextGetter(
       base_path_(base_path),
       io_loop_(io_loop),
       file_loop_(file_loop),
+      url_sec_mgr_(net::URLSecurityManager::Create(NULL, NULL)),
       protocol_interceptors_(protocol_interceptors.Pass()) {
   // Must first be created on the UI thread.
   DCHECK(BrowserThread::CurrentlyOn(BrowserThread::UI));
@@ -189,7 +189,6 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
               NULL,
               url_request_context_->network_delegate()));
 
-    auto url_sec_mgr = net::URLSecurityManager::Create(NULL, NULL);
 
     std::vector<std::string> schemes;
     schemes.push_back(std::string("basic"));
@@ -200,7 +199,7 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
     auto auth_handler_factory =
         net::HttpAuthHandlerRegistryFactory::Create(
             schemes,
-            url_sec_mgr,
+            url_sec_mgr_.get(),
             host_resolver.get(),
             std::string(),  // gssapi_library_name
             false,          // negotiate_disable_cname_lookup

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -198,13 +198,13 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
     schemes.push_back(std::string("negotiate"));
 
     auto auth_handler_factory =
-      net::HttpAuthHandlerRegistryFactory::Create(
-        schemes,
-        url_sec_mgr,
-        host_resolver.get(),
-        std::string(),  // gssapi_library_name
-        false,          // negotiate_disable_cname_lookup
-        true);          // negotiate_enable_port
+        net::HttpAuthHandlerRegistryFactory::Create(
+            schemes,
+            url_sec_mgr,
+            host_resolver.get(),
+            std::string(),  // gssapi_library_name
+            false,          // negotiate_disable_cname_lookup
+            true);          // negotiate_enable_port
 
     storage_->set_cert_verifier(net::CertVerifier::CreateDefault());
     storage_->set_transport_security_state(new net::TransportSecurityState);

--- a/browser/url_request_context_getter.h
+++ b/browser/url_request_context_getter.h
@@ -9,6 +9,7 @@
 #include "base/memory/scoped_ptr.h"
 #include "content/public/browser/content_browser_client.h"
 #include "net/http/http_cache.h"
+#include "net/http/url_security_manager.h"
 #include "net/url_request/url_request_context_getter.h"
 
 namespace base {
@@ -68,6 +69,7 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
   scoped_ptr<net::URLRequestContextStorage> storage_;
   scoped_ptr<net::URLRequestContext> url_request_context_;
   scoped_ptr<net::HostMappingRules> host_mapping_rules_;
+  scoped_ptr<net::URLSecurityManager> url_sec_mgr_;
   content::ProtocolHandlerMap protocol_handlers_;
   content::URLRequestInterceptorScopedVector protocol_interceptors_;
 


### PR DESCRIPTION
The `HttpAuthHandlerFactory::CreateDefault` method does not set a URLSecurityManager, so the code will fall-back to disabling all integrated authentication. Instead, use the default URLSecurityManager which will use IE Security Zones on Windows to determine whether a URL is part of the Local Intranet zone or on non-Windows, default proxy rules will be used (i.e. would a default proxy  map vs. connect direct).

## TODO:

- [x] Fix my slop memory management