### PR TITLE
method to reset devtools agent host

### DIFF
--- a/browser/inspectable_web_contents.h
+++ b/browser/inspectable_web_contents.h
@@ -3,6 +3,10 @@
 
 #include "content/public/browser/web_contents.h"
 
+namespace content {
+class DevToolsAgentHost;
+}
+
 namespace brightray {
 
 class InspectableWebContentsDelegate;
@@ -27,6 +31,7 @@ class InspectableWebContents {
   // Close the DevTools completely instead of just hide it.
   virtual void CloseDevTools() = 0;
   virtual bool IsDevToolsViewShowing() = 0;
+  virtual void AttachTo(const scoped_refptr<content::DevToolsAgentHost>&) = 0;
 
   // The delegate manages its own life.
   virtual void SetDelegate(InspectableWebContentsDelegate* delegate) = 0;

--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -188,6 +188,18 @@ bool InspectableWebContentsImpl::IsDevToolsViewShowing() {
   return devtools_web_contents_ && view_->IsDevToolsViewShowing();
 }
 
+void InspectableWebContentsImpl::AttachTo(const scoped_refptr<content::DevToolsAgentHost>& host) {
+  if (agent_host_.get())
+    Detach();
+  agent_host_ = host;
+  agent_host_->AttachClient(this);
+}
+
+void InspectableWebContentsImpl::Detach() {
+  agent_host_->DetachClient();
+  agent_host_ = nullptr;
+}
+
 gfx::Rect InspectableWebContentsImpl::GetDevToolsBounds() const {
   return devtools_bounds_;
 }

--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -48,6 +48,9 @@ class InspectableWebContentsImpl :
   void ShowDevTools() override;
   void CloseDevTools() override;
   bool IsDevToolsViewShowing() override;
+  void AttachTo(const scoped_refptr<content::DevToolsAgentHost>&) override;
+
+  void Detach();  
 
   // Return the last position and size of devtools window.
   gfx::Rect GetDevToolsBounds() const;


### PR DESCRIPTION
currently using to set serviceworker agent host to already opened devtools, #80 can also use this as its easy to get agent host for webcontents.