### PR TITLE
Make devtools work when web security is enabled

### DIFF
--- a/browser/devtools_ui.cc
+++ b/browser/devtools_ui.cc
@@ -42,11 +42,12 @@ std::string GetMimeTypeForPath(const std::string& path) {
     return "image/png";
   } else if (EndsWith(filename, ".gif", false)) {
     return "image/gif";
+  } else if (EndsWith(filename, ".svg", false)) {
+    return "image/svg+xml";
   } else if (EndsWith(filename, ".manifest", false)) {
     return "text/cache-manifest";
   }
-  NOTREACHED();
-  return "text/plain";
+  return "text/html";
 }
 
 class BundledDataSource : public content::URLDataSource {
@@ -84,6 +85,14 @@ class BundledDataSource : public content::URLDataSource {
 
   virtual bool ShouldAddContentSecurityPolicy() const override {
     return false;
+  }
+
+  virtual bool ShouldDenyXFrameOptions() const override {
+    return false;
+  }
+
+  virtual bool ShouldServeMimeTypeAsContentTypeHeader() const override {
+    return true;
   }
 
  private:


### PR DESCRIPTION
These changes bring our copy of devtools_ui.cc in line with https://chromium.googlesource.com/chromium/src.git/+/43.0.2357.92/chrome/browser/ui/webui/devtools_ui.cc

Without these changes, opening the devtools prints errors like:

    [0602/165604:ERROR:CONSOLE(0)] "Refused to display 'chrome-devtools://devtools/inspector.html?can_dock=true&toolbarColor=rgba(223,223,223,1)&textColor=rgba(0,0,0,1)&experiments=true' in a frame because it set 'X-Frame-Options' to 'DENY'.", source: about:blank (0)
    [0602/165604:ERROR:CONSOLE(1514)] "Uncaught SecurityError: Sandbox access violation: Blocked a frame at "chrome-devtools://devtools" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.", source: chrome-devtools://devtools/devtools.js (1514)

/cc @zcbenz 