### PR TITLE
adding support for kLogNetLog switch

### DIFF
--- a/browser/net_log.cc
+++ b/browser/net_log.cc
@@ -34,7 +34,11 @@ NetLog::NetLog(net::URLRequestContext* context)
       LOG(ERROR) << "Could not open file: " << log_path.value()
                  << "for net logging";
 
-    fprintf(log_file_.get(), "{\"events\": [\n");
+    std::string json;
+    scoped_ptr<base::Value> constants = net::GetNetConstants();
+    base::JSONWriter::Write(constants.release(), &json);
+    fprintf(log_file_.get(), "{\"constants\": %s, \n", json.c_str());
+    fprintf(log_file_.get(), "\"events\": [\n");
 
     if (context_.get()) {
       DCHECK(context_->CalledOnValidThread());

--- a/browser/net_log.cc
+++ b/browser/net_log.cc
@@ -1,0 +1,66 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "browser/net_log.h"
+
+#include "browser/browser_context.h"
+#include "base/command_line.h"
+#include "base/files/file_util.h"
+#include "base/json/json_writer.h"
+#include "base/logging.h"
+#include "content/public/common/content_switches.h"
+#include "net/log/net_log_util.h"
+#include "net/url_request/url_request_context.h"
+
+namespace brightray {
+
+NetLog::NetLog(net::URLRequestContext* context)
+    : added_events_(false),
+      context_(context) {
+  auto command_line = base::CommandLine::ForCurrentProcess();
+
+  if (command_line->HasSwitch(switches::kLogNetLog)) {
+    base::FilePath log_path =
+        command_line->GetSwitchValuePath(switches::kLogNetLog);
+
+    #if defined(OS_WIN)
+      log_file_.reset(_wfopen(log_path.value().c_str(), L"w"));
+    #elif defined(OS_POSIX)
+      log_file_.reset(fopen(log_path.value().c_str(), "w"));
+    #endif
+
+    if (!log_file_)
+      LOG(ERROR) << "Could not open file: " << log_path.value()
+                 << "for net logging";
+
+    fprintf(log_file_.get(), "{\"events\": [\n");
+
+    if (context_.get()) {
+      DCHECK(context_->CalledOnValidThread());
+
+      std::set<net::URLRequestContext*> contexts;
+      contexts.insert(context_.get());
+
+      net::CreateNetLogEntriesForActiveObjects(contexts, this);
+    }
+
+    DeprecatedAddObserver(this, net::NetLog::LogLevel::LOG_STRIP_PRIVATE_DATA);
+  }
+}
+
+NetLog::~NetLog() {
+  DeprecatedRemoveObserver(this);
+  fprintf(log_file_.get(), "]}");
+  log_file_.reset();
+}
+
+void NetLog::OnAddEntry(const net::NetLog::Entry& entry) {
+  std::string json;
+  base::JSONWriter::Write(entry.ToValue(), &json);
+
+  fprintf(log_file_.get(), "%s%s", (added_events_ ? ",\n" : ""), json.c_str());
+  added_events_ = true;
+}
+
+}  // namespace brightray

--- a/browser/net_log.cc
+++ b/browser/net_log.cc
@@ -51,7 +51,8 @@ NetLog::NetLog(net::URLRequestContext* context)
                << "for net logging";
   } else {
     std::string json;
-    base::JSONWriter::Write(GetConstants(), &json);
+    scoped_ptr<base::Value> constants(GetConstants());
+    base::JSONWriter::Write(constants.get(), &json);
     fprintf(log_file_.get(), "{\"constants\": %s, \n", json.c_str());
     fprintf(log_file_.get(), "\"events\": [\n");
 

--- a/browser/net_log.h
+++ b/browser/net_log.h
@@ -19,13 +19,14 @@ class NetLog : public net::NetLog,
                public net::NetLog::ThreadSafeObserver {
  public:
   explicit NetLog(net::URLRequestContext* context);
-  virtual ~NetLog();
+  ~NetLog() override;
 
   void OnAddEntry(const net::NetLog::Entry& entry) override;
 
  private:
   bool added_events_;
-  scoped_ptr<net::URLRequestContext> context_;
+  // We use raw pointer to prevent reference cycle.
+  net::URLRequestContext* const context_;
   base::ScopedFILE log_file_;
 
   DISALLOW_COPY_AND_ASSIGN(NetLog);

--- a/browser/net_log.h
+++ b/browser/net_log.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef BROWSER_NET_LOG_H_
+#define BROWSER_NET_LOG_H_
+
+#include "base/files/file_path.h"
+#include "base/files/scoped_file.h"
+#include "net/log/net_log.h"
+
+namespace net {
+class URLRequestContext;
+}
+
+namespace brightray {
+
+class NetLog : public net::NetLog,
+               public net::NetLog::ThreadSafeObserver {
+ public:
+  explicit NetLog(net::URLRequestContext* context);
+  virtual ~NetLog();
+
+  void OnAddEntry(const net::NetLog::Entry& entry) override;
+
+ private:
+  bool added_events_;
+  scoped_ptr<net::URLRequestContext> context_;
+  base::ScopedFILE log_file_;
+
+  DISALLOW_COPY_AND_ASSIGN(NetLog);
+};
+
+}  // namespace brightray
+
+#endif  // BROWSER_NET_LOG_H_

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -148,8 +148,13 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
   auto& command_line = *base::CommandLine::ForCurrentProcess();
   if (!url_request_context_.get()) {
     url_request_context_.reset(new net::URLRequestContext);
-    net_log_.reset(new NetLog(url_request_context_.get()));
-    url_request_context_->set_net_log(net_log_.get());
+
+    // --log-net-log
+    if (command_line.HasSwitch(switches::kLogNetLog)) {
+      net_log_.reset(new NetLog(url_request_context_.get()));
+      url_request_context_->set_net_log(net_log_.get());
+    }
+
     network_delegate_.reset(delegate_->CreateNetworkDelegate());
     url_request_context_->set_network_delegate(network_delegate_.get());
 

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -22,6 +22,7 @@
 #include "net/dns/mapped_host_resolver.h"
 #include "net/http/http_auth_handler_factory.h"
 #include "net/http/http_server_properties_impl.h"
+#include "net/log/net_log.h"
 #include "net/proxy/dhcp_proxy_script_fetcher_factory.h"
 #include "net/proxy/proxy_config_service.h"
 #include "net/proxy/proxy_script_fetcher_impl.h"
@@ -147,7 +148,8 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
   auto& command_line = *base::CommandLine::ForCurrentProcess();
   if (!url_request_context_.get()) {
     url_request_context_.reset(new net::URLRequestContext);
-    url_request_context_->set_net_log(new NetLog(url_request_context_.get()));
+    net_log_.reset(new NetLog(url_request_context_.get()));
+    url_request_context_->set_net_log(net_log_.get());
     network_delegate_.reset(delegate_->CreateNetworkDelegate());
     url_request_context_->set_network_delegate(network_delegate_.get());
 

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 
+#include "browser/net_log.h"
 #include "browser/network_delegate.h"
 
 #include "base/command_line.h"
@@ -146,6 +147,7 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
   auto& command_line = *base::CommandLine::ForCurrentProcess();
   if (!url_request_context_.get()) {
     url_request_context_.reset(new net::URLRequestContext);
+    url_request_context_->set_net_log(new NetLog(url_request_context_.get()));
     network_delegate_.reset(delegate_->CreateNetworkDelegate());
     url_request_context_->set_network_delegate(network_delegate_.get());
 
@@ -161,7 +163,7 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
     storage_->set_http_user_agent_settings(new net::StaticHttpUserAgentSettings(
         "en-us,en", base::EmptyString()));
 
-    scoped_ptr<net::HostResolver> host_resolver(net::HostResolver::CreateDefaultResolver(NULL));
+    scoped_ptr<net::HostResolver> host_resolver(net::HostResolver::CreateDefaultResolver(nullptr));
 
     // --host-resolver-rules
     if (command_line.HasSwitch(switches::kHostResolverRules)) {
@@ -226,6 +228,7 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
         url_request_context_->channel_id_service();
     network_session_params.http_auth_handler_factory =
         url_request_context_->http_auth_handler_factory();
+    network_session_params.net_log = url_request_context_->net_log();
 
     // --ignore-certificate-errors
     if (command_line.HasSwitch(switches::kIgnoreCertificateErrors))

--- a/browser/url_request_context_getter.h
+++ b/browser/url_request_context_getter.h
@@ -17,6 +17,7 @@ class MessageLoop;
 }
 
 namespace net {
+class NetLog;
 class HostMappingRules;
 class HostResolver;
 class NetworkDelegate;
@@ -65,6 +66,7 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
   base::MessageLoop* file_loop_;
 
   scoped_ptr<net::ProxyConfigService> proxy_config_service_;
+  scoped_ptr<net::NetLog> net_log_;
   scoped_ptr<net::NetworkDelegate> network_delegate_;
   scoped_ptr<net::URLRequestContextStorage> storage_;
   scoped_ptr<net::URLRequestContext> url_request_context_;

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -37,6 +37,8 @@
       'browser/media/media_capture_devices_dispatcher.h',
       'browser/media/media_stream_devices_controller.cc',
       'browser/media/media_stream_devices_controller.h',
+      'browser/net_log.cc',
+      'browser/net_log.h',
       'browser/network_delegate.cc',
       'browser/network_delegate.h',
       'browser/notification_presenter.h',


### PR DESCRIPTION
users can now create a net log events dump file and load into `chrome://net-internals` for insight.

- [x] Add NetConstants to load the json
- [ ] Confirm the usage of deprecate observer [methods](https://code.google.com/p/chromium/issues/detail?id=472693) though the CL has put them behind deprecation, they are used primarily in [ChromeNetLog](https://code.google.com/p/chromium/codesearch#chromium/src/net/log/write_to_file_net_log_observer.cc&sq=package:chromium&rcl=1433490588&l=70) .