### PR TITLE
Make devtools_web_contents_ is destroyed before everything

### DIFF
--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -159,10 +159,10 @@ void InspectableWebContentsImpl::RegisterPrefs(PrefRegistrySimple* registry) {
 
 InspectableWebContentsImpl::InspectableWebContentsImpl(
     content::WebContents* web_contents)
-    : web_contents_(web_contents),
-      frontend_loaded_(false),
+    : frontend_loaded_(false),
       can_dock_(true),
       delegate_(nullptr),
+      web_contents_(web_contents),
       weak_factory_(this) {
   auto context = static_cast<BrowserContext*>(web_contents_->GetBrowserContext());
   auto bounds_dict = context->prefs()->GetDictionary(kDevToolsBoundsPref);

--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -147,10 +147,6 @@ class InspectableWebContentsImpl :
   void SendMessageAck(int request_id,
                       const base::Value* arg1);
 
-  scoped_ptr<content::WebContents> web_contents_;
-  scoped_ptr<content::WebContents> devtools_web_contents_;
-  scoped_ptr<InspectableWebContentsView> view_;
-
   bool frontend_loaded_;
   scoped_refptr<content::DevToolsAgentHost> agent_host_;
   scoped_ptr<content::DevToolsFrontendHost> frontend_host_;
@@ -160,10 +156,14 @@ class InspectableWebContentsImpl :
   gfx::Rect devtools_bounds_;
   bool can_dock_;
 
-  InspectableWebContentsDelegate* delegate_;  // weak references.
-
   using PendingRequestsMap = std::map<const net::URLFetcher*, DispatchCallback>;
   PendingRequestsMap pending_requests_;
+  InspectableWebContentsDelegate* delegate_;  // weak references.
+
+  scoped_ptr<InspectableWebContentsView> view_;
+  scoped_ptr<content::WebContents> web_contents_;
+  scoped_ptr<content::WebContents> devtools_web_contents_;
+
   base::WeakPtrFactory<InspectableWebContentsImpl> weak_factory_;
 
   DISALLOW_COPY_AND_ASSIGN(InspectableWebContentsImpl);


### PR DESCRIPTION
The WebContentsDestroyed still access the other members, so if they are
destroyed before the devtools_web_contents_ in the destructor, we will
crash there.

@hokein Can you try if this fixes the crash(https://github.com/atom/electron/issues/1901)?