### PR TITLE
adding delegate class to receive notifications

### DIFF
--- a/browser/browser_context.cc
+++ b/browser/browser_context.cc
@@ -6,7 +6,6 @@
 
 #include "browser/brightray_paths.h"
 #include "browser/inspectable_web_contents_impl.h"
-#include "browser/network_delegate.h"
 #include "browser/permission_manager.h"
 #include "common/application_info.h"
 
@@ -115,7 +114,7 @@ net::URLRequestContextGetter* BrowserContext::CreateRequestContext(
 }
 
 net::NetworkDelegate* BrowserContext::CreateNetworkDelegate() {
-  return new NetworkDelegate;
+  return new NetworkDelegate(CreateBrightrayNetworkDelegate());
 }
 
 base::FilePath BrowserContext::GetPath() const {

--- a/browser/browser_context.h
+++ b/browser/browser_context.h
@@ -5,6 +5,7 @@
 #ifndef BRIGHTRAY_BROWSER_BROWSER_CONTEXT_H_
 #define BRIGHTRAY_BROWSER_BROWSER_CONTEXT_H_
 
+#include "browser/network_delegate.h"
 #include "browser/permission_manager.h"
 #include "browser/url_request_context_getter.h"
 
@@ -24,6 +25,10 @@ class BrowserContext : public content::BrowserContext,
   ~BrowserContext();
 
   virtual void Initialize();
+
+  // Subclasses should override this to receive network notifications.
+  virtual brightray::NetworkDelegate::Delegate*
+      CreateBrightrayNetworkDelegate() { return nullptr; }
 
   net::URLRequestContextGetter* CreateRequestContext(
       content::ProtocolHandlerMap* protocol_handlers,

--- a/browser/network_delegate.h
+++ b/browser/network_delegate.h
@@ -14,7 +14,22 @@ namespace brightray {
 
 class NetworkDelegate : public net::NetworkDelegate {
  public:
-  NetworkDelegate();
+  class Delegate {
+    public:
+     Delegate() {}
+     virtual ~Delegate() {}
+
+     virtual int BeforeSendHeaders(net::URLRequest* request,
+                                   const net::CompletionCallback& callback,
+                                   net::HttpRequestHeaders* headers);
+     virtual AuthRequiredResponse AuthRequired(
+        net::URLRequest* request,
+        const net::AuthChallengeInfo& auth_info,
+        const AuthCallback& callback,
+        net::AuthCredentials* credentials);
+  };
+
+  NetworkDelegate(Delegate* delegate);
   virtual ~NetworkDelegate();
 
  protected:
@@ -73,7 +88,7 @@ class NetworkDelegate : public net::NetworkDelegate {
 
  private:
   std::vector<std::string> ignore_connections_limit_domains_;
-
+  Delegate* delegate_;
   DISALLOW_COPY_AND_ASSIGN(NetworkDelegate);
 };
 


### PR DESCRIPTION
this lets embedders of brightray recevie network notifications, the use case is to implement `webcontents.webrequest` api on election . Thoughts ?