### PR TITLE
Ensure we don't try to set notification contentImage on < OS X 10.9

### DIFF
--- a/browser/notification_presenter_mac.mm
+++ b/browser/notification_presenter_mac.mm
@@ -8,6 +8,7 @@
 #include "base/bind.h"
 #include "base/stl_util.h"
 #include "base/mac/mac_util.h"
+#include "base/mac/sdk_forward_declarations.h"
 #include "base/strings/sys_string_conversions.h"
 #include "content/public/common/platform_notification_data.h"
 #include "content/public/browser/desktop_notification_delegate.h"
@@ -49,7 +50,9 @@ void NotificationPresenterMac::ShowNotification(
   auto notification = [[NSUserNotification alloc] init];
   notification.title = base::SysUTF16ToNSString(data.title);
   notification.informativeText = base::SysUTF16ToNSString(data.body);
-  notification.contentImage = gfx::SkBitmapToNSImageWithColorSpace(icon, base::mac::GetGenericRGBColorSpace());
+
+  if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_9)
+    notification.contentImage = gfx::SkBitmapToNSImageWithColorSpace(icon, base::mac::GetGenericRGBColorSpace());
 
   notifications_map_[delegate.get()].reset(notification);
   [NSUserNotificationCenter.defaultUserNotificationCenter deliverNotification:notification];


### PR DESCRIPTION
This PR avoids a crash on 10.7/10.8 where contentImage is not available