### PR TITLE
create netlog instance for devtoolsnetlogobserver

### DIFF
--- a/browser/browser_client.cc
+++ b/browser/browser_client.cc
@@ -80,6 +80,10 @@ void BrowserClient::GetAdditionalAllowedSchemesForFileSystem(
   additional_schemes->push_back(content::kChromeUIScheme);
 }
 
+net::NetLog* BrowserClient::GetNetLog() {
+  return browser_context()->GetNetLog();
+}
+
 base::FilePath BrowserClient::GetDefaultDownloadDirectory() {
   // ~/Downloads
   base::FilePath path;

--- a/browser/browser_client.h
+++ b/browser/browser_client.h
@@ -43,6 +43,7 @@ class BrowserClient : public content::ContentBrowserClient {
   content::PlatformNotificationService* GetPlatformNotificationService() override;
   void GetAdditionalAllowedSchemesForFileSystem(
       std::vector<std::string>* additional_schemes) override;
+  net::NetLog* GetNetLog() override;
   base::FilePath GetDefaultDownloadDirectory() override;
   content::DevToolsManagerDelegate* GetDevToolsManagerDelegate() override;
 

--- a/browser/browser_context.cc
+++ b/browser/browser_context.cc
@@ -114,6 +114,10 @@ net::URLRequestContextGetter* BrowserContext::CreateRequestContext(
   return url_request_getter_.get();
 }
 
+net::NetLog* BrowserContext::GetNetLog() {
+  return url_request_getter_->net_log();
+}
+
 net::NetworkDelegate* BrowserContext::CreateNetworkDelegate() {
   return new NetworkDelegate;
 }

--- a/browser/browser_context.h
+++ b/browser/browser_context.h
@@ -48,6 +48,7 @@ class BrowserContext : public content::BrowserContext,
   net::URLRequestContextGetter* CreateRequestContext(
       content::ProtocolHandlerMap* protocol_handlers,
       content::URLRequestInterceptorScopedVector protocol_interceptors);
+  net::NetLog* GetNetLog();
 
   net::URLRequestContextGetter* url_request_context_getter() const {
     return url_request_getter_.get();

--- a/browser/net_log.cc
+++ b/browser/net_log.cc
@@ -36,44 +36,48 @@ NetLog::NetLog(net::URLRequestContext* context)
     : added_events_(false),
       context_(context) {
   auto command_line = base::CommandLine::ForCurrentProcess();
-  base::FilePath log_path =
-      command_line->GetSwitchValuePath(switches::kLogNetLog);
+  if (command_line->HasSwitch(switches::kLogNetLog)) {
+    base::FilePath log_path =
+        command_line->GetSwitchValuePath(switches::kLogNetLog);
 
-  #if defined(OS_WIN)
-    log_file_.reset(_wfopen(log_path.value().c_str(), L"w"));
-  #elif defined(OS_POSIX)
-    log_file_.reset(fopen(log_path.value().c_str(), "w"));
-  #endif
+    #if defined(OS_WIN)
+      log_file_.reset(_wfopen(log_path.value().c_str(), L"w"));
+    #elif defined(OS_POSIX)
+      log_file_.reset(fopen(log_path.value().c_str(), "w"));
+    #endif
 
-  if (!log_file_) {
-    LOG(ERROR) << "Could not open file: " << log_path.value()
-               << "for net logging";
-  } else {
-    std::string json;
-    scoped_ptr<base::Value> constants(GetConstants().Pass());
-    base::JSONWriter::Write(constants.get(), &json);
-    fprintf(log_file_.get(), "{\"constants\": %s, \n", json.c_str());
-    fprintf(log_file_.get(), "\"events\": [\n");
+    if (!log_file_) {
+      LOG(ERROR) << "Could not open file: " << log_path.value()
+                << "for net logging";
+    } else {
+      std::string json;
+      scoped_ptr<base::Value> constants(GetConstants().Pass());
+      base::JSONWriter::Write(constants.get(), &json);
+      fprintf(log_file_.get(), "{\"constants\": %s, \n", json.c_str());
+      fprintf(log_file_.get(), "\"events\": [\n");
 
-    if (context_) {
-      DCHECK(context_->CalledOnValidThread());
+      if (context_) {
+        DCHECK(context_->CalledOnValidThread());
 
-      std::set<net::URLRequestContext*> contexts;
-      contexts.insert(context_);
+        std::set<net::URLRequestContext*> contexts;
+        contexts.insert(context_);
 
-      net::CreateNetLogEntriesForActiveObjects(contexts, this);
+        net::CreateNetLogEntriesForActiveObjects(contexts, this);
+      }
+
+      DeprecatedAddObserver(this, net::NetLog::LogLevel::LOG_STRIP_PRIVATE_DATA);
     }
-
-    DeprecatedAddObserver(this, net::NetLog::LogLevel::LOG_STRIP_PRIVATE_DATA);
   }
 }
 
 NetLog::~NetLog() {
-  DeprecatedRemoveObserver(this);
+  if (log_file_) {
+    DeprecatedRemoveObserver(this);
 
-  // Ending events array.
-  fprintf(log_file_.get(), "]}");
-  log_file_.reset();
+    // Ending events array.
+    fprintf(log_file_.get(), "]}");
+    log_file_.reset();
+  }
 }
 
 void NetLog::OnAddEntry(const net::NetLog::Entry& entry) {

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -150,10 +150,8 @@ net::URLRequestContext* URLRequestContextGetter::GetURLRequestContext() {
     url_request_context_.reset(new net::URLRequestContext);
 
     // --log-net-log
-    if (command_line.HasSwitch(switches::kLogNetLog)) {
-      net_log_.reset(new NetLog(url_request_context_.get()));
-      url_request_context_->set_net_log(net_log_.get());
-    }
+    net_log_.reset(new NetLog(url_request_context_.get()));
+    url_request_context_->set_net_log(net_log_.get());
 
     network_delegate_.reset(delegate_->CreateNetworkDelegate());
     url_request_context_->set_network_delegate(network_delegate_.get());

--- a/browser/url_request_context_getter.h
+++ b/browser/url_request_context_getter.h
@@ -57,6 +57,7 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
   scoped_refptr<base::SingleThreadTaskRunner> GetNetworkTaskRunner() const override;
 
   net::HostResolver* host_resolver();
+  net::NetLog* net_log() { return net_log_.get(); }
 
  private:
   Delegate* delegate_;


### PR DESCRIPTION
Fixes https://github.com/atom/electron/issues/1852


Devtools network panel info is based on values extracted from netlog trace in [DevToolsNetLogObserver](https://code.google.com/p/chromium/codesearch#chromium/src/content/browser/devtools/devtools_netlog_observer.h) , so its required to have netlog created and returned in `ContentClient::GetNetLog`.

with this patch devtools network info should be aligned with regular chrome devtools
![screenshot from 2015-07-14 23-17-17](https://cloud.githubusercontent.com/assets/964386/8680434/f11148d4-2a7e-11e5-8112-61f7405e9a60.png)


/cc @zcbenz @hokein 