### PR TITLE
save devtools zoom level preference

### DIFF
--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -19,6 +19,7 @@
 #include "net/url_request/url_fetcher_delegate.h"
 #include "ui/gfx/geometry/rect.h"
 
+class PrefService;
 class PrefRegistrySimple;
 
 namespace content {
@@ -64,6 +65,10 @@ class InspectableWebContentsImpl :
   // Return the last position and size of devtools window.
   gfx::Rect GetDevToolsBounds() const;
   void SaveDevToolsBounds(const gfx::Rect& bounds);
+
+  // Return the last set zoom level of devtools window.
+  double GetDevToolsZoomLevel() const;
+  void UpdateDevToolsZoomLevel(double level);
 
  private:
   // DevToolsEmbedderMessageDispacher::Delegate
@@ -159,6 +164,8 @@ class InspectableWebContentsImpl :
   using PendingRequestsMap = std::map<const net::URLFetcher*, DispatchCallback>;
   PendingRequestsMap pending_requests_;
   InspectableWebContentsDelegate* delegate_;  // weak references.
+
+  PrefService* pref_service_; // weak reference.
 
   scoped_ptr<content::WebContents> web_contents_;
   scoped_ptr<content::WebContents> devtools_web_contents_;


### PR DESCRIPTION
Fixes https://github.com/atom/electron/issues/2324

if its desired to maintain zoom level for all webcontent hosts then could setup preferences in `BrowserContext::ZoomLevelDelegate::InitHostZoomMap` , thoughts ?