### PR TITLE
Allowing devtools window to update title

### DIFF
--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -23,6 +23,7 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/devtools_http_handler.h"
 #include "content/public/browser/host_zoom_map.h"
+#include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "net/http/http_response_headers.h"
@@ -49,6 +50,7 @@ const char kDevToolsZoomPref[] = "brightray.devtools.zoom";
 const char kFrontendHostId[] = "id";
 const char kFrontendHostMethod[] = "method";
 const char kFrontendHostParams[] = "params";
+const char kTitleFormat[] = "Developer Tools - %s";
 
 const char kDevToolsActionTakenHistogram[] = "DevTools.ActionTaken";
 const int kDevToolsActionTakenBoundary = 100;
@@ -346,6 +348,8 @@ void InspectableWebContentsImpl::InspectElementCompleted() {
 }
 
 void InspectableWebContentsImpl::InspectedURLChanged(const std::string& url) {
+  view_->SetTitle(base::UTF8ToUTF16(base::StringPrintf(kTitleFormat,
+                                                       url.c_str())));
 }
 
 void InspectableWebContentsImpl::LoadNetworkResource(

--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -23,7 +23,6 @@
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/devtools_http_handler.h"
 #include "content/public/browser/host_zoom_map.h"
-#include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_view_host.h"
 #include "net/http/http_response_headers.h"

--- a/browser/inspectable_web_contents_view.h
+++ b/browser/inspectable_web_contents_view.h
@@ -1,6 +1,7 @@
 #ifndef BRIGHTRAY_BROWSER_INSPECTABLE_WEB_CONTENTS_VIEW_H_
 #define BRIGHTRAY_BROWSER_INSPECTABLE_WEB_CONTENTS_VIEW_H_
 
+#include "base/strings/string16.h"
 #include "ui/gfx/native_widget_types.h"
 
 class DevToolsContentsResizingStrategy;
@@ -46,6 +47,7 @@ class InspectableWebContentsView {
   virtual void SetIsDocked(bool docked) = 0;
   virtual void SetContentsResizingStrategy(
       const DevToolsContentsResizingStrategy& strategy) = 0;
+  virtual void SetTitle(const base::string16& title) = 0;
 
  private:
   InspectableWebContentsViewDelegate* delegate_;  // weak references.

--- a/browser/inspectable_web_contents_view_mac.h
+++ b/browser/inspectable_web_contents_view_mac.h
@@ -24,6 +24,7 @@ class InspectableWebContentsViewMac : public InspectableWebContentsView {
   void SetIsDocked(bool docked) override;
   void SetContentsResizingStrategy(
       const DevToolsContentsResizingStrategy& strategy) override;
+  void SetTitle(const base::string16& title) override;
 
   InspectableWebContentsImpl* inspectable_web_contents() {
     return inspectable_web_contents_;

--- a/browser/inspectable_web_contents_view_mac.mm
+++ b/browser/inspectable_web_contents_view_mac.mm
@@ -50,4 +50,8 @@ void InspectableWebContentsViewMac::SetContentsResizingStrategy(
   [view_ setContentsResizingStrategy:strategy];
 }
 
+void InspectableWebContentsViewMac::SetTitle(const base::string16& title) {
+  [view_ setTitle:title];
+}
+
 }

--- a/browser/mac/bry_inspectable_web_contents_view.h
+++ b/browser/mac/bry_inspectable_web_contents_view.h
@@ -32,5 +32,6 @@ using brightray::InspectableWebContentsViewMac;
 - (BOOL)isDevToolsVisible;
 - (void)setIsDocked:(BOOL)docked;
 - (void)setContentsResizingStrategy:(const DevToolsContentsResizingStrategy&)strategy;
+- (void)setTitle:(const base::string16&)title;
 
 @end

--- a/browser/mac/bry_inspectable_web_contents_view.mm
+++ b/browser/mac/bry_inspectable_web_contents_view.mm
@@ -2,6 +2,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 
+#include "base/strings/sys_string_conversions.h"
 #include "browser/inspectable_web_contents_impl.h"
 #include "browser/inspectable_web_contents_view_mac.h"
 
@@ -172,6 +173,13 @@ const CGFloat kRoundedCornerRadius = 4;
       &new_devtools_bounds, &new_contents_bounds);
   [devToolsView setFrame:[self flipRectToNSRect:new_devtools_bounds]];
   [contentsView setFrame:[self flipRectToNSRect:new_contents_bounds]];
+}
+
+- (void)setTitle:(const base::string16&)title {
+  if (devtools_window_) {
+    NSString* title_string = base::SysUTF16ToNSString(title);
+    [devtools_window_ setTitle:title_string];
+  }
 }
 
 // Creates a path whose bottom two corners are rounded.

--- a/browser/views/inspectable_web_contents_view_views.h
+++ b/browser/views/inspectable_web_contents_view_views.h
@@ -14,6 +14,10 @@ class Widget;
 
 namespace brightray {
 
+namespace {
+class DevToolsWindowDelegate;
+}
+
 class InspectableWebContentsImpl;
 
 class InspectableWebContentsViewViews : public InspectableWebContentsView,
@@ -22,6 +26,10 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
   explicit InspectableWebContentsViewViews(
       InspectableWebContentsImpl* inspectable_web_contents_impl);
   ~InspectableWebContentsViewViews();
+
+  DevToolsWindowDelegate* GetDevToolsWindowDelegate() const {
+    return devtools_window_delegate_;
+  }
 
   // InspectableWebContentsView:
   views::View* GetView() override;
@@ -32,6 +40,7 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
   void SetIsDocked(bool docked) override;
   void SetContentsResizingStrategy(
       const DevToolsContentsResizingStrategy& strategy) override;
+  void SetTitle(const base::string16& title) override;
 
   InspectableWebContentsImpl* inspectable_web_contents() {
     return inspectable_web_contents_;
@@ -51,6 +60,7 @@ class InspectableWebContentsViewViews : public InspectableWebContentsView,
 
   DevToolsContentsResizingStrategy strategy_;
   bool devtools_visible_;
+  DevToolsWindowDelegate* devtools_window_delegate_;
 
   DISALLOW_COPY_AND_ASSIGN(InspectableWebContentsViewViews);
 };


### PR DESCRIPTION
This aligns with how chromium treats devtools window title in undocked mode. Havnt tested the osx implmentation. Eases associating a devtools window to the inspected page.