### PR TITLE
Rewrite Ubuntu check to look for libunity .so files

### DIFF
--- a/browser/linux/notification_presenter_linux.cc
+++ b/browser/linux/notification_presenter_linux.cc
@@ -13,6 +13,7 @@
 #include "content/public/browser/desktop_notification_delegate.h"
 #include "content/public/common/platform_notification_data.h"
 #include "common/application_info.h"
+#include <stdlib.h>
 #include "third_party/skia/include/core/SkBitmap.h"
 
 using namespace base;
@@ -30,6 +31,11 @@ static bool UnityIsRunning() {
 
   if (unity_has_result) {
     return unity_result;
+  }
+
+  if (getenv("ELECTRON_USE_UBUNTU_NOTIFIER")) {
+    unity_result = true;
+    goto out;
   }
  
   // Look for the presence of libunity as our hint that we're under Ubuntu

--- a/browser/linux/notification_presenter_linux.cc
+++ b/browser/linux/notification_presenter_linux.cc
@@ -7,13 +7,16 @@
 
 #include "base/bind.h"
 #include "base/logging.h"
+#include "base/files/file_enumerator.h"
 #include "base/strings/utf_string_conversions.h"
 #include "chrome/browser/ui/libgtk2ui/skia_utils_gtk2.h"
 #include "content/public/browser/desktop_notification_delegate.h"
 #include "content/public/common/platform_notification_data.h"
 #include "common/application_info.h"
-#include "dbus/dbus.h"
 #include "third_party/skia/include/core/SkBitmap.h"
+
+using namespace base;
+using namespace std;
 
 namespace brightray {
 
@@ -23,34 +26,29 @@ static bool unity_has_result = false;
 static bool unity_result = false;
 
 static bool UnityIsRunning() {
+  FileEnumerator* enumerator = NULL;
+
   if (unity_has_result) {
     return unity_result;
   }
+ 
+  // Look for the presence of libunity as our hint that we're under Ubuntu
+  FilePath haystack;
+  string needle("/usr/lib/libunity-");
 
-  struct DBusError err;
-  struct DBusConnection* bus = NULL;
-
-  dbus_error_init(&err);
-
-  bus = dbus_bus_get(DBUS_BUS_SESSION, &err);
-  if (dbus_error_is_set(&err)) {
-    g_debug("Failed to get Session Bus reference");
-    unity_result = false;
-    dbus_error_free(&err);
-
-    goto out;
+  enumerator = new FileEnumerator(FilePath("/usr/lib"), false, FileEnumerator::FILES);
+  
+  while (!((haystack = enumerator->Next()).empty())) {
+    if (haystack.value().compare(0, needle.length(), needle) == 0) {
+      unity_result = true;
+      goto out;
+    }
   }
-
-  unity_result = dbus_bus_name_has_owner(bus, "com.canonical.indicator.session", &err);
-
-  if (dbus_error_is_set(&err)) {
-    unity_result = false;
-    dbus_error_free(&err);
-  }
-
-out:
-  if (bus) dbus_connection_unref(bus);
-
+  
+  unity_result = false;
+  
+out: 
+  if (enumerator) delete enumerator;
   unity_has_result = true;
   return unity_result;
 }


### PR DESCRIPTION
This PR fixes the issue in #135 by using the presence of Unity .so files as our canary for detecting Ubuntu's patched notifier (which won't be perfect either sadly, but will pick up more cases). We also add an `ELECTRON_USE_UBUNTU_NOTIFIER` to force this, which users can use if our heuristic fails

Fixes #135 