### PR TITLE
Don't reference the bsm dylib directly.

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -153,7 +153,7 @@
                   '$(SDKROOT)/System/Library/Frameworks/CoreFoundation.framework',
                   '$(SDKROOT)/System/Library/Frameworks/IOKit.framework',
                   # content_browser.gypi:
-                  '$(SDKROOT)/usr/lib/libbsm.dylib',
+                  '-lbsm',
                   # bluetooth.gyp:
                   '$(SDKROOT)/System/Library/Frameworks/IOBluetooth.framework',
                 ],


### PR DESCRIPTION
https://forums.developer.apple.com/thread/4572 is the best reference I
could find for this.

Apple replaced (some?) dylibs with “text-based stub libraries”
(.tbd’s) in Xcode 7. So we shouldn’t try to reference the dylib directly anymore.