### PR TITLE
Add option to build local libchromiumcontent

### DIFF
--- a/brightray.gypi
+++ b/brightray.gypi
@@ -3,16 +3,15 @@
     'vendor/download/libchromiumcontent/filenames.gypi',
   ],
   'variables': {
-    'libchromiumcontent_src_dir': '<(libchromiumcontent_root_dir)/src',
     'libchromiumcontent_component%': 1,
     'conditions': [
       # The "libchromiumcontent_component" is defined when calling "gyp".
       ['libchromiumcontent_component', {
-        'libchromiumcontent_dir%': '<(libchromiumcontent_root_dir)/shared_library',
+        'libchromiumcontent_dir%': '<(libchromiumcontent_shared_libraries_dir)',
         'libchromiumcontent_libraries%': '<(libchromiumcontent_shared_libraries)',
         'libchromiumcontent_v8_libraries%': '<(libchromiumcontent_shared_v8_libraries)',
       }, {
-        'libchromiumcontent_dir%': '<(libchromiumcontent_root_dir)/static_library',
+        'libchromiumcontent_dir%': '<(libchromiumcontent_static_libraries_dir)',
         'libchromiumcontent_libraries%': '<(libchromiumcontent_static_libraries)',
         'libchromiumcontent_v8_libraries%': '<(libchromiumcontent_static_v8_libraries)',
       }],

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -14,9 +14,28 @@ DOWNLOAD_DIR = os.path.join(VENDOR_DIR, 'download')
 
 def main():
   args = parse_args()
-
+  if (args.libcc_source_path != None and
+      args.libcc_shared_library_path != None and
+      args.libcc_static_library_path != None):
+    if (not os.path.isdir(args.libcc_source_path)):
+      print "Error: Directory does not exist:", args.libcc_source_path
+      sys.exit(0)
+    elif (not os.path.isdir(args.libcc_shared_library_path)):
+      print "Error: Directory does not exist:", args.libcc_shared_library_path
+      sys.exit(0)
+    elif (not os.path.isdir(args.libcc_static_library_path)):
+      print "Error: Directory does not exist:", args.libcc_static_library_path
+      sys.exit(0)
+  elif (args.libcc_source_path != None or
+        args.libcc_shared_library_path != None or
+        args.libcc_static_library_path != None):
+    print "Error: All options of libchromiumcontent are required OR let brightray choose it"
+    sys.exit(0)
   update_submodules()
-  download_libchromiumcontent(args.dev, args.commit, args.target_arch, args.url)
+  setup_libchromiumcontent(args.dev, args.commit, args.target_arch, args.url,
+                           args.libcc_source_path,
+                           args.libcc_shared_library_path,
+                           args.libcc_static_library_path)
 
 
 def parse_args():
@@ -30,6 +49,12 @@ def parse_args():
   parser.add_argument('url', help='The base URL from which to download '
                       'libchromiumcontent (i.e., the URL you passed to '
                       'libchromiumcontent\'s script/upload script')
+  parser.add_argument('--libcc_source_path', required=False,
+                        help='The source path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let brightray choose it')
+  parser.add_argument('--libcc_shared_library_path', required=False,
+                        help='The shared library path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let brightray choose it')
+  parser.add_argument('--libcc_static_library_path', required=False,
+                        help='The static library path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let brightray choose it')
   return parser.parse_args()
 
 
@@ -39,17 +64,25 @@ def update_submodules():
                            '--recursive']))
 
 
-def download_libchromiumcontent(is_dev, commit, target_arch, url):
-  mkdir_p(DOWNLOAD_DIR)
-  download = os.path.join(VENDOR_DIR, 'libchromiumcontent', 'script',
-                          'download')
-  target_dir = os.path.join(DOWNLOAD_DIR, 'libchromiumcontent')
-  args = ['-f', '-c', commit, '--target_arch', target_arch, url, target_dir]
-  if is_dev:
-    subprocess.check_call([sys.executable, download] + args)
-  else:
-    subprocess.check_call([sys.executable, download, '-s'] + args)
-
+def setup_libchromiumcontent(is_dev, commit, target_arch, url,
+                             libcc_source_path,
+                             libcc_shared_library_path,
+                             libcc_static_library_path):
+    mkdir_p(DOWNLOAD_DIR)
+    target_dir = os.path.join(DOWNLOAD_DIR, 'libchromiumcontent')
+    download = os.path.join(VENDOR_DIR, 'libchromiumcontent', 'script',
+                            'download')
+    args = ['-f', '-c', commit, '--target_arch', target_arch, url, target_dir]
+    if (libcc_source_path != None and
+        libcc_shared_library_path != None and
+        libcc_static_library_path != None):
+          args.append(['--libcc_source_path', libcc_source_path,
+                      '--libcc_shared_library_path', libcc_shared_library_path,
+                      '--libcc_static_library_path', libcc_static_library_path])
+    if is_dev:
+        subprocess.check_call([sys.executable, download] + args)
+    else:
+        subprocess.check_call([sys.executable, download, '-s'] + args)
 
 def mkdir_p(path):
   try:


### PR DESCRIPTION
- Currently libchromiumcontent is downloaded by default.
- Now developer can choose to provide local libchromiumcontent src, shared and static path

Tries to solve similar issue noted in: [atom/electron#3310]