### PR TITLE
Ensure Notifications are Windows 8+ Only

### DIFF
--- a/browser/platform_notification_service_impl.cc
+++ b/browser/platform_notification_service_impl.cc
@@ -8,6 +8,10 @@
 
 #include "content/public/browser/desktop_notification_delegate.h"
 
+#if defined(OS_WIN)
+#include "base/win/windows_version.h"
+#endif
+
 namespace brightray {
 
 // static
@@ -20,8 +24,16 @@ PlatformNotificationServiceImpl::PlatformNotificationServiceImpl() {}
 PlatformNotificationServiceImpl::~PlatformNotificationServiceImpl() {}
 
 NotificationPresenter* PlatformNotificationServiceImpl::notification_presenter() {
-  if (!notification_presenter_)
+  if (!notification_presenter_) {
+    #if defined(OS_WIN)
+    // Bail out if on Windows 7 or even lower, no operating will follow
+    if (base::win::GetVersion() < base::win::VERSION_WIN8) {
+      return notification_presenter_.get();
+    }
+    #endif
+    // Create a new presenter if on OS X, Linux, or Windows 8+
     notification_presenter_.reset(NotificationPresenter::Create());
+  }
   return notification_presenter_.get();
 }
 


### PR DESCRIPTION
Things aren't pretty on Windows 7, so let's not even try to create a `NotificationPresenter` if we're on Windows 7 or lower.