### PR TITLE
Delay Load WinRT Libraries, Full Compat with Windows 7

### DIFF
--- a/brightray.gyp
+++ b/brightray.gyp
@@ -161,17 +161,6 @@
           ]
         }],  # OS=="mac"
         ['OS=="win"', {
-          'msvs_settings': {
-            'VCLinkerTool': {
-              'AdditionalDependencies': [
-                # Windows Runtime.
-                'crypt32.lib',
-                'runtimeobject.lib',
-                'shlwapi.lib',
-                'windowsapp.lib',
-              ],
-            },
-          },
           'conditions': [
             ['libchromiumcontent_component', {
               # sandbox, base_static, devtools_discovery, devtools_http_handler,
@@ -231,6 +220,9 @@
                       'BluetoothApis.dll',
                       'Bthprops.cpl',
                       'setupapi.dll',
+                      # windows runtime
+                      'API-MS-WIN-CORE-WINRT-L1-1-0.DLL',
+                      'API-MS-WIN-CORE-WINRT-STRING-L1-1-0.DLL',
                     ],
                   },
                 },

--- a/browser/win/notification_presenter_win.cc
+++ b/browser/win/notification_presenter_win.cc
@@ -14,11 +14,6 @@
 
 #pragma comment(lib, "runtimeobject.lib")
 
-using namespace Microsoft::WRL;
-using namespace ABI::Windows::UI::Notifications;
-using namespace ABI::Windows::Data::Xml::Dom;
-using namespace ABI::Windows::Foundation;
-
 namespace brightray {
 
 namespace {

--- a/browser/win/windows_toast_notification.cc
+++ b/browser/win/windows_toast_notification.cc
@@ -16,6 +16,7 @@ namespace brightray {
 namespace {
 
 // Initialize Windows Runtime
+
 HRESULT init = Windows::Foundation::Initialize(RO_INIT_MULTITHREADED);
 
 }  // namespace
@@ -57,7 +58,7 @@ void WindowsToastNotification::ShowNotification(
   if (!toast_str.success())
     return;
 
-  ComPtr<IToastNotificationFactory> toast_factory;
+  ComPtr<ABI::Windows::UI::Notifications::IToastNotificationFactory> toast_factory;
   if (FAILED(Windows::Foundation::GetActivationFactory(toast_str,
                                                        &toast_factory)))
     return;
@@ -90,24 +91,24 @@ void WindowsToastNotification::NotificationDismissed() {
 }
 
 bool WindowsToastNotification::GetToastXml(
-    IToastNotificationManagerStatics* toastManager,
+    ABI::Windows::UI::Notifications::IToastNotificationManagerStatics* toastManager,
     const std::wstring& title,
     const std::wstring& msg,
     std::string icon_path,
     IXmlDocument** toast_xml) {
-  ToastTemplateType template_type;
+  ABI::Windows::UI::Notifications::ToastTemplateType template_type;
   if (title.empty() || msg.empty()) {
     // Single line toast.
-    template_type = icon_path.empty() ? ToastTemplateType_ToastText01 :
-                                        ToastTemplateType_ToastImageAndText01;
+    template_type = icon_path.empty() ? ABI::Windows::UI::Notifications::ToastTemplateType_ToastText01 :
+                                        ABI::Windows::UI::Notifications::ToastTemplateType_ToastImageAndText01;
     if (FAILED(toast_manager_->GetTemplateContent(template_type, toast_xml)))
       return false;
     if (!SetXmlText(*toast_xml, title.empty() ? msg : title))
       return false;
   } else {
     // Title and body toast.
-    template_type = icon_path.empty() ? ToastTemplateType_ToastText02 :
-                                        ToastTemplateType_ToastImageAndText02;
+    template_type = icon_path.empty() ? ABI::Windows::UI::Notifications::ToastTemplateType_ToastText02 :
+                                        ABI::Windows::UI::Notifications::ToastTemplateType_ToastImageAndText02;
     if (FAILED(toastManager->GetTemplateContent(template_type, toast_xml)))
       return false;
     if (!SetXmlText(*toast_xml, title, msg))
@@ -234,7 +235,7 @@ bool WindowsToastNotification::AppendTextToXml(
   return SUCCEEDED(node->AppendChild(text_node.Get(), &append_node));
 }
 
-bool WindowsToastNotification::SetupCallbacks(IToastNotification* toast) {
+bool WindowsToastNotification::SetupCallbacks(ABI::Windows::UI::Notifications::IToastNotification* toast) {
   EventRegistrationToken activatedToken, dismissedToken;
   event_handler_ = Make<ToastEventHandler>(this);
   if (FAILED(toast->add_Activated(event_handler_.Get(), &activatedToken)))
@@ -254,13 +255,14 @@ ToastEventHandler::~ToastEventHandler() {
 }
 
 IFACEMETHODIMP ToastEventHandler::Invoke(
-    IToastNotification* sender, IInspectable* args) {
+    ABI::Windows::UI::Notifications::IToastNotification* sender, IInspectable* args) {
   notification_->NotificationClicked();
   return S_OK;
 }
 
 IFACEMETHODIMP ToastEventHandler::Invoke(
-    IToastNotification* sender, IToastDismissedEventArgs* e) {
+    ABI::Windows::UI::Notifications::IToastNotification* sender,
+    ABI::Windows::UI::Notifications::IToastDismissedEventArgs* e) {
   notification_->NotificationDismissed();
   return S_OK;
 }

--- a/browser/win/windows_toast_notification.h
+++ b/browser/win/windows_toast_notification.h
@@ -16,17 +16,17 @@
 #include "content/public/common/platform_notification_data.h"
 
 using namespace Microsoft::WRL;
-using namespace ABI::Windows::UI::Notifications;
-using namespace ABI::Windows::Foundation;
 
 class ScopedHString;
 
 namespace brightray {
 
 using DesktopToastActivatedEventHandler =
-    ITypedEventHandler<ToastNotification*, IInspectable*>;
+    ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Notifications::ToastNotification*,
+    IInspectable*>;
 using DesktopToastDismissedEventHandler =
-    ITypedEventHandler<ToastNotification*, ToastDismissedEventArgs*>;
+    ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Notifications::ToastNotification*,
+    ABI::Windows::UI::Notifications::ToastDismissedEventArgs*>;
 
 class WindowsToastNotification {
  public:
@@ -50,7 +50,7 @@ class WindowsToastNotification {
   void NotificationClicked();
   void NotificationDismissed();
 
-  bool GetToastXml(IToastNotificationManagerStatics* toastManager,
+  bool GetToastXml(ABI::Windows::UI::Notifications::IToastNotificationManagerStatics* toastManager,
                    const std::wstring& title,
                    const std::wstring& msg,
                    std::string icon_path,
@@ -69,13 +69,13 @@ class WindowsToastNotification {
   bool AppendTextToXml(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                        ABI::Windows::Data::Xml::Dom::IXmlNode* node,
                        const std::wstring& text);
-  bool SetupCallbacks(IToastNotification* toast);
+  bool SetupCallbacks(ABI::Windows::UI::Notifications::IToastNotification* toast);
 
   scoped_ptr<content::DesktopNotificationDelegate> delegate_;
   ComPtr<ToastEventHandler> event_handler_;
-  ComPtr<IToastNotificationManagerStatics> toast_manager_;
-  ComPtr<IToastNotifier> toast_notifier_;
-  ComPtr<IToastNotification> toast_notification_;
+  ComPtr<ABI::Windows::UI::Notifications::IToastNotificationManagerStatics> toast_manager_;
+  ComPtr<ABI::Windows::UI::Notifications::IToastNotifier> toast_notifier_;
+  ComPtr<ABI::Windows::UI::Notifications::IToastNotification> toast_notification_;
 
   base::WeakPtrFactory<WindowsToastNotification> weak_factory_;
 
@@ -90,8 +90,8 @@ class ToastEventHandler : public RuntimeClass<RuntimeClassFlags<ClassicCom>,
   ToastEventHandler(WindowsToastNotification* notification);
   ~ToastEventHandler();
 
-  IFACEMETHODIMP Invoke(IToastNotification* sender, IInspectable* args);
-  IFACEMETHODIMP Invoke(IToastNotification* sender, IToastDismissedEventArgs* e);
+  IFACEMETHODIMP Invoke(ABI::Windows::UI::Notifications::IToastNotification* sender, IInspectable* args);
+  IFACEMETHODIMP Invoke(ABI::Windows::UI::Notifications::IToastNotification* sender, ABI::Windows::UI::Notifications::IToastDismissedEventArgs* e);
 
  private:
   WindowsToastNotification* notification_;  // weak ref.


### PR DESCRIPTION
We were still missing DLLs on Windows 7 (and therefore refused to launch) - this patch ensures full compatibility with Windows 7.