### PR TITLE
Change how Helper process is detected

### DIFF
--- a/common/mac/main_application_bundle.mm
+++ b/common/mac/main_application_bundle.mm
@@ -5,10 +5,10 @@
 
 #import "common/mac/main_application_bundle.h"
 
-#import "common/mac/foundation_util.h"
-
-#import "base/files/file_path.h"
-#import "base/path_service.h"
+#include "base/files/file_path.h"
+#include "base/mac/foundation_util.h"
+#include "base/path_service.h"
+#include "base/strings/string_util.h"
 
 namespace brightray {
 
@@ -18,7 +18,7 @@ base::FilePath MainApplicationBundlePath() {
   PathService::Get(base::FILE_EXE, &path);
 
   // Up to Contents.
-  if (base::mac::IsBackgroundOnlyProcess()) {
+  if (base::EndsWith(path.value(), " Helper", base::CompareCase::SENSITIVE)) {
     // The running executable is the helper. Go up five steps:
     // Contents/Frameworks/Helper.app/Contents/MacOS/Helper
     // ^ to here                                     ^ from here

--- a/common/mac/main_application_bundle.mm
+++ b/common/mac/main_application_bundle.mm
@@ -6,11 +6,21 @@
 #import "common/mac/main_application_bundle.h"
 
 #include "base/files/file_path.h"
+#include "base/mac/bundle_locations.h"
 #include "base/mac/foundation_util.h"
 #include "base/path_service.h"
 #include "base/strings/string_util.h"
 
 namespace brightray {
+
+namespace {
+
+bool HasMainProcessKey() {
+  NSDictionary* info_dictionary = [base::mac::MainBundle() infoDictionary];
+  return [[info_dictionary objectForKey:@"ElectronMainProcess"] boolValue] != NO;
+}
+
+}  // namespace
 
 base::FilePath MainApplicationBundlePath() {
   // Start out with the path to the running executable.
@@ -18,7 +28,8 @@ base::FilePath MainApplicationBundlePath() {
   PathService::Get(base::FILE_EXE, &path);
 
   // Up to Contents.
-  if (base::EndsWith(path.value(), " Helper", base::CompareCase::SENSITIVE)) {
+  if (!HasMainProcessKey() &&
+      base::EndsWith(path.value(), " Helper", base::CompareCase::SENSITIVE)) {
     // The running executable is the helper. Go up five steps:
     // Contents/Frameworks/Helper.app/Contents/MacOS/Helper
     // ^ to here                                     ^ from here
@@ -40,4 +51,4 @@ NSBundle* MainApplicationBundle() {
   return [NSBundle bundleWithPath:base::mac::FilePathToNSString(MainApplicationBundlePath())];
 }
 
-}
+}  // namespace brightray


### PR DESCRIPTION
Using `IsBackgroundOnlyProcess` is not reliable since the main process can also be a background process. Checking whether process name ends with ` Helper` is obviously not an ideal solution, but if someone is really crazy enough to use `XXX Helper` as their app's name, they can add `ElectronMainProcess` key in `Info.plist` to work around this.

Fix https://github.com/atom/electron/issues/1369.