### PR TITLE
devtools: exclude devtools related http header from serviceworker context

### DIFF
--- a/browser/net/devtools_network_transaction.cc
+++ b/browser/net/devtools_network_transaction.cc
@@ -15,12 +15,10 @@
 
 namespace brightray {
 
-namespace {
-
-const char kDevToolsEmulateNetworkConditionsClientId[] =
-    "X-DevTools-Emulate-Network-Conditions-Client-Id";
-
-}  // namespace
+// static
+const char
+    DevToolsNetworkTransaction::kDevToolsEmulateNetworkConditionsClientId[] =
+        "X-DevTools-Emulate-Network-Conditions-Client-Id";
 
 DevToolsNetworkTransaction::DevToolsNetworkTransaction(
     DevToolsNetworkController* controller,

--- a/browser/net/devtools_network_transaction.h
+++ b/browser/net/devtools_network_transaction.h
@@ -22,6 +22,8 @@ class DevToolsNetworkInterceptor;
 
 class DevToolsNetworkTransaction : public net::HttpTransaction {
  public:
+  static const char kDevToolsEmulateNetworkConditionsClientId[];
+
   DevToolsNetworkTransaction(
       DevToolsNetworkController* controller,
       scoped_ptr<net::HttpTransaction> network_transaction);

--- a/browser/net/devtools_network_transaction_factory.cc
+++ b/browser/net/devtools_network_transaction_factory.cc
@@ -7,6 +7,7 @@
 #include "browser/net/devtools_network_controller.h"
 #include "browser/net/devtools_network_transaction.h"
 
+#include "content/public/browser/service_worker_context.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_network_layer.h"
 #include "net/http/http_network_transaction.h"
@@ -18,6 +19,10 @@ DevToolsNetworkTransactionFactory::DevToolsNetworkTransactionFactory(
     net::HttpNetworkSession* session)
     : controller_(controller),
       network_layer_(new net::HttpNetworkLayer(session)) {
+  std::set<std::string> headers;
+  headers.insert(
+      DevToolsNetworkTransaction::kDevToolsEmulateNetworkConditionsClientId);
+  content::ServiceWorkerContext::AddExcludedHeadersForFetchEvent(headers);
 }
 
 DevToolsNetworkTransactionFactory::~DevToolsNetworkTransactionFactory() {


### PR DESCRIPTION
Fixes https://github.com/atom/electron/issues/3831

otherwise accept headers will be set.
![screenshot from 2015-12-19 02-37-00](https://cloud.githubusercontent.com/assets/964386/11907381/72d87bda-a5f9-11e5-913a-c0b5d3da3605.png)

Related chromium [issue](https://code.google.com/p/chromium/issues/detail?id=419318)