### PR TITLE
Load libnotify dynamically

### DIFF
--- a/browser/linux/libnotify_loader.cc
+++ b/browser/linux/libnotify_loader.cc
@@ -1,0 +1,113 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: tools/generate_library_loader/generate_library_loader.py .
+
+#include "browser/linux/libnotify_loader.h"
+
+#include <dlfcn.h>
+
+LibNotifyLoader::LibNotifyLoader() : loaded_(false) {
+}
+
+LibNotifyLoader::~LibNotifyLoader() {
+  CleanUp(loaded_);
+}
+
+bool LibNotifyLoader::Load(const std::string& library_name) {
+  if (loaded_)
+    return false;
+
+  library_ = dlopen(library_name.c_str(), RTLD_LAZY);
+  if (!library_)
+    return false;
+
+  notify_is_initted =
+      reinterpret_cast<decltype(this->notify_is_initted)>(
+          dlsym(library_, "notify_is_initted"));
+  notify_is_initted = &::notify_is_initted;
+  if (!notify_is_initted) {
+    CleanUp(true);
+    return false;
+  }
+
+  notify_init =
+      reinterpret_cast<decltype(this->notify_init)>(
+          dlsym(library_, "notify_init"));
+  notify_init = &::notify_init;
+  if (!notify_init) {
+    CleanUp(true);
+    return false;
+  }
+
+  notify_notification_new =
+      reinterpret_cast<decltype(this->notify_notification_new)>(
+          dlsym(library_, "notify_notification_new"));
+  notify_notification_new = &::notify_notification_new;
+  if (!notify_notification_new) {
+    CleanUp(true);
+    return false;
+  }
+
+  notify_notification_add_action =
+      reinterpret_cast<decltype(this->notify_notification_add_action)>(
+          dlsym(library_, "notify_notification_add_action"));
+  notify_notification_add_action = &::notify_notification_add_action;
+  if (!notify_notification_add_action) {
+    CleanUp(true);
+    return false;
+  }
+
+  notify_notification_set_image_from_pixbuf =
+      reinterpret_cast<decltype(this->notify_notification_set_image_from_pixbuf)>(
+          dlsym(library_, "notify_notification_set_image_from_pixbuf"));
+  notify_notification_set_image_from_pixbuf = &::notify_notification_set_image_from_pixbuf;
+  if (!notify_notification_set_image_from_pixbuf) {
+    CleanUp(true);
+    return false;
+  }
+
+  notify_notification_set_timeout =
+      reinterpret_cast<decltype(this->notify_notification_set_timeout)>(
+          dlsym(library_, "notify_notification_set_timeout"));
+  notify_notification_set_timeout = &::notify_notification_set_timeout;
+  if (!notify_notification_set_timeout) {
+    CleanUp(true);
+    return false;
+  }
+
+  notify_notification_show =
+      reinterpret_cast<decltype(this->notify_notification_show)>(
+          dlsym(library_, "notify_notification_show"));
+  notify_notification_show = &::notify_notification_show;
+  if (!notify_notification_show) {
+    CleanUp(true);
+    return false;
+  }
+
+  notify_notification_close =
+      reinterpret_cast<decltype(this->notify_notification_close)>(
+          dlsym(library_, "notify_notification_close"));
+  notify_notification_close = &::notify_notification_close;
+  if (!notify_notification_close) {
+    CleanUp(true);
+    return false;
+  }
+
+  loaded_ = true;
+  return true;
+}
+
+void LibNotifyLoader::CleanUp(bool unload) {
+  if (unload) {
+    dlclose(library_);
+    library_ = NULL;
+  }
+  loaded_ = false;
+  notify_is_initted = NULL;
+  notify_init = NULL;
+  notify_notification_new = NULL;
+  notify_notification_add_action = NULL;
+  notify_notification_set_image_from_pixbuf = NULL;
+  notify_notification_set_timeout = NULL;
+  notify_notification_show = NULL;
+  notify_notification_close = NULL;
+}

--- a/browser/linux/libnotify_loader.h
+++ b/browser/linux/libnotify_loader.h
@@ -1,0 +1,41 @@
+// This is generated file. Do not modify directly.
+// Path to the code generator: tools/generate_library_loader/generate_library_loader.py .
+
+#ifndef BRIGHTRAY_BROWSER_LINUX_LIBNOTIFY_LOADER_H_
+#define BRIGHTRAY_BROWSER_LINUX_LIBNOTIFY_LOADER_H_
+
+#include <string>
+
+#include <libnotify/notify.h>
+
+class LibNotifyLoader {
+ public:
+  LibNotifyLoader();
+  ~LibNotifyLoader();
+
+  bool Load(const std::string& library_name)
+      __attribute__((warn_unused_result));
+
+  bool loaded() const { return loaded_; }
+
+  decltype(&::notify_is_initted) notify_is_initted;
+  decltype(&::notify_init) notify_init;
+  decltype(&::notify_notification_new) notify_notification_new;
+  decltype(&::notify_notification_add_action) notify_notification_add_action;
+  decltype(&::notify_notification_set_image_from_pixbuf) notify_notification_set_image_from_pixbuf;
+  decltype(&::notify_notification_set_timeout) notify_notification_set_timeout;
+  decltype(&::notify_notification_show) notify_notification_show;
+  decltype(&::notify_notification_close) notify_notification_close;
+
+ private:
+  void CleanUp(bool unload);
+
+  void* library_;
+  bool loaded_;
+
+  // Disallow copy constructor and assignment operator.
+  LibNotifyLoader(const LibNotifyLoader&);
+  void operator=(const LibNotifyLoader&);
+};
+
+#endif  // BRIGHTRAY_BROWSER_LINUX_LIBNOTIFY_LOADER_H_

--- a/browser/linux/notification_presenter_linux.h
+++ b/browser/linux/notification_presenter_linux.h
@@ -6,11 +6,10 @@
 #ifndef BRIGHTRAY_BROWSER_NOTIFICATION_PRESENTER_LINUX_H_
 #define BRIGHTRAY_BROWSER_NOTIFICATION_PRESENTER_LINUX_H_
 
-#include <libnotify/notify.h>
-
 #include <map>
 
 #include "base/compiler_specific.h"
+#include "browser/linux/libnotify_loader.h"
 #include "browser/notification_presenter.h"
 #include "ui/base/glib/glib_signal.h"
 
@@ -21,6 +20,7 @@ class NotificationPresenterLinux : public NotificationPresenter {
   NotificationPresenterLinux();
   ~NotificationPresenterLinux();
 
+  bool Init();
   void RemoveNotification(NotifyNotification *notification);
 
  private:
@@ -37,6 +37,8 @@ class NotificationPresenterLinux : public NotificationPresenter {
   CHROMEG_CALLBACK_0(NotificationPresenterLinux, void, OnNotificationClosed, NotifyNotification*);
   CHROMEG_CALLBACK_1(NotificationPresenterLinux, void, OnNotificationView, NotifyNotification*,
                      char*);
+
+  LibNotifyLoader libnotify_loader_;
 
   // A list of all open NotifyNotification objects.
   // We do lookups here both by NotifyNotification object (when the user

--- a/filenames.gypi
+++ b/filenames.gypi
@@ -61,6 +61,8 @@
       'browser/permission_manager.h',
       'browser/platform_notification_service_impl.cc',
       'browser/platform_notification_service_impl.h',
+      'browser/linux/libnotify_loader.h',
+      'browser/linux/libnotify_loader.cc',
       'browser/linux/notification_presenter_linux.h',
       'browser/linux/notification_presenter_linux.cc',
       'browser/win/notification_presenter_win.h',


### PR DESCRIPTION
Instead of linking with libnotify, we now just load the library dynamically, so we no longer need to worry whether a specific version of libnotify exists, and we can avoid possible crashes caused by using wrong version of libnotify.

Fix https://github.com/atom/electron/issues/2294.