### PR TITLE
Load content_shell.pak for current scale factor

### DIFF
--- a/common/main_delegate.cc
+++ b/common/main_delegate.cc
@@ -48,9 +48,10 @@ void MainDelegate::InitializeResourceBundle() {
   path = pak_dir.Append(FILE_PATH_LITERAL("content_shell.pak"));
 #endif
 
-  ui::ResourceBundle::InitSharedInstanceWithLocale("", NULL,
+  ui::ResourceBundle::InitSharedInstanceWithLocale("", nullptr,
       ui::ResourceBundle::DO_NOT_LOAD_COMMON_RESOURCES);
-  ui::ResourceBundle::GetSharedInstance().AddDataPackFromPath(path, ui::SCALE_FACTOR_100P);
+  ui::ResourceBundle::GetSharedInstance().AddDataPackFromPath(
+      path, ui::GetSupportedScaleFactors()[0]);
   AddDataPackFromPath(&ui::ResourceBundle::GetSharedInstance(), path.DirName());
 }
 


### PR DESCRIPTION
Otherwise devices with scale factor other than 1x will not have the resource loaded.