### PR TITLE
Add Silent Notification Support

### DIFF
--- a/browser/linux/libnotify_notification.cc
+++ b/browser/linux/libnotify_notification.cc
@@ -89,7 +89,8 @@ LibnotifyNotification::~LibnotifyNotification() {
 void LibnotifyNotification::Show(const base::string16& title,
                                  const base::string16& body,
                                  const GURL& icon_url,
-                                 const SkBitmap& icon) {
+                                 const SkBitmap& icon,
+                                 const bool silent) {
   notification_ = libnotify_loader_.notify_notification_new(
       base::UTF16ToUTF8(title).c_str(),
       base::UTF16ToUTF8(body).c_str(),

--- a/browser/linux/libnotify_notification.h
+++ b/browser/linux/libnotify_notification.h
@@ -23,7 +23,8 @@ class LibnotifyNotification : public Notification {
   void Show(const base::string16& title,
             const base::string16& msg,
             const GURL& icon_url,
-            const SkBitmap& icon) override;
+            const SkBitmap& icon,
+            const bool silent) override;
   void Dismiss() override;
 
  private:

--- a/browser/mac/cocoa_notification.h
+++ b/browser/mac/cocoa_notification.h
@@ -23,7 +23,8 @@ class CocoaNotification : public Notification {
   void Show(const base::string16& title,
             const base::string16& msg,
             const GURL& icon_url,
-            const SkBitmap& icon) override;
+            const SkBitmap& icon,
+            const bool silent) override;
   void Dismiss() override;
 
   void NotifyDisplayed();

--- a/browser/mac/cocoa_notification.mm
+++ b/browser/mac/cocoa_notification.mm
@@ -31,7 +31,8 @@ CocoaNotification::~CocoaNotification() {
 void CocoaNotification::Show(const base::string16& title,
                              const base::string16& body,
                              const GURL& icon_url,
-                             const SkBitmap& icon) {
+                             const SkBitmap& icon,
+                             const bool silent) {
   notification_.reset([[NSUserNotification alloc] init]);
   [notification_ setTitle:base::SysUTF16ToNSString(title)];
   [notification_ setInformativeText:base::SysUTF16ToNSString(body)];
@@ -41,6 +42,12 @@ void CocoaNotification::Show(const base::string16& title,
     NSImage* image = gfx::SkBitmapToNSImageWithColorSpace(
         icon, base::mac::GetGenericRGBColorSpace());
     [notification_ setContentImage:image];
+  }
+  
+  if (silent) {
+    [notification_ setSoundName:nil];
+  } else {
+    [notification_ setSoundName:NSUserNotificationDefaultSoundName];
   }
 
   [NSUserNotificationCenter.defaultUserNotificationCenter

--- a/browser/notification.h
+++ b/browser/notification.h
@@ -22,7 +22,8 @@ class Notification {
   virtual void Show(const base::string16& title,
                     const base::string16& msg,
                     const GURL& icon_url,
-                    const SkBitmap& icon) = 0;
+                    const SkBitmap& icon,
+                    const bool silent) = 0;
   // Closes the notification, this instance will be destroyed after the
   // notification gets closed.
   virtual void Dismiss() = 0;

--- a/browser/platform_notification_service.cc
+++ b/browser/platform_notification_service.cc
@@ -57,7 +57,7 @@ void PlatformNotificationService::DisplayNotification(
   auto notification = presenter->CreateNotification(adapter.get());
   if (notification) {
     ignore_result(adapter.release());  // it will release itself automatically.
-    notification->Show(data.title, data.body, data.icon, icon);
+    notification->Show(data.title, data.body, data.icon, icon, data.silent);
     *cancel_callback = base::Bind(&RemoveNotification, notification);
   }
 }

--- a/browser/win/windows_toast_notification.h
+++ b/browser/win/windows_toast_notification.h
@@ -42,7 +42,8 @@ class WindowsToastNotification : public Notification {
   void Show(const base::string16& title,
             const base::string16& msg,
             const GURL& icon_url,
-            const SkBitmap& icon) override;
+            const SkBitmap& icon,
+            const bool silent) override;
   void Dismiss() override;
 
  private:
@@ -56,7 +57,9 @@ class WindowsToastNotification : public Notification {
                    const std::wstring& title,
                    const std::wstring& msg,
                    const std::wstring& icon_path,
+                   const bool silent,
                    ABI::Windows::Data::Xml::Dom::IXmlDocument** toastXml);
+  bool SetXmlAudioSilent(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc);
   bool SetXmlText(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                   const std::wstring& text);
   bool SetXmlText(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,


### PR DESCRIPTION
 * Implements support for silent notifications on Windows and OS X
 * Exposes bool `silent` to Linux notification presenters

Closes https://github.com/atom/electron/issues/4169