### PR TITLE
allow client to decide displaying web notifications

### DIFF
--- a/browser/browser_client.h
+++ b/browser/browser_client.h
@@ -28,6 +28,9 @@ class BrowserClient : public content::ContentBrowserClient {
 
   NotificationPresenter* GetNotificationPresenter();
 
+  // Subclasses should override this to enable or disable WebNotification.
+  virtual bool WebNotificationAllowed(int render_process_id) { return true; }
+
  protected:
   // Subclasses should override this to provide their own BrowserMainParts
   // implementation. The lifetime of the returned instance is managed by the

--- a/browser/platform_notification_service.cc
+++ b/browser/platform_notification_service.cc
@@ -23,7 +23,8 @@ void RemoveNotification(base::WeakPtr<Notification> notification) {
 
 PlatformNotificationService::PlatformNotificationService(
     BrowserClient* browser_client)
-    : browser_client_(browser_client) {
+    : browser_client_(browser_client),
+      render_process_id_(0) {
 }
 
 PlatformNotificationService::~PlatformNotificationService() {}
@@ -32,6 +33,7 @@ blink::WebNotificationPermission PlatformNotificationService::CheckPermissionOnU
     content::BrowserContext* browser_context,
     const GURL& origin,
     int render_process_id) {
+  render_process_id_ = render_process_id;
   return blink::WebNotificationPermissionAllowed;
 }
 
@@ -49,6 +51,8 @@ void PlatformNotificationService::DisplayNotification(
     const content::PlatformNotificationData& data,
     scoped_ptr<content::DesktopNotificationDelegate> delegate,
     base::Closure* cancel_callback) {
+  if (!browser_client_->WebNotificationAllowed(render_process_id_))
+    return;
   auto presenter = browser_client_->GetNotificationPresenter();
   if (!presenter)
     return;

--- a/browser/platform_notification_service.h
+++ b/browser/platform_notification_service.h
@@ -48,6 +48,7 @@ class PlatformNotificationService
       std::set<std::string>* displayed_notifications) override;
 
  private:
+  int render_process_id_;
   BrowserClient* browser_client_;
 
   DISALLOW_COPY_AND_ASSIGN(PlatformNotificationService);


### PR DESCRIPTION
Took the simpler approach, the better way would have been to send an ipc across and obtain the permission but there is plans to remove IO checks for web notification https://code.google.com/p/chromium/issues/detail?id=446497 , so wasnt worth the effort to follow that approach. Only caveat is `Notification.permission` will remain `granted`, but that shouldnt be a problem i guess. Thoughts ?