### PR TITLE
Updates to Chrome 49 on Win32

### DIFF
--- a/browser/devtools_contents_resizing_strategy.h
+++ b/browser/devtools_contents_resizing_strategy.h
@@ -5,7 +5,7 @@
 #ifndef BRIGHTRAY_BROWSER_DEVTOOLS_CONTENTS_RESIZING_STRATEGY_H_
 #define BRIGHTRAY_BROWSER_DEVTOOLS_CONTENTS_RESIZING_STRATEGY_H_
 
-#include "base/basictypes.h"
+#include "base/macros.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/geometry/size.h"

--- a/browser/devtools_manager_delegate.cc
+++ b/browser/devtools_manager_delegate.cc
@@ -55,7 +55,7 @@ class TCPServerSocketFactory
   }
 
   std::string address_;
-  uint16 port_;
+  uint16_t port_;
 
   DISALLOW_COPY_AND_ASSIGN(TCPServerSocketFactory);
 };

--- a/browser/devtools_manager_delegate.h
+++ b/browser/devtools_manager_delegate.h
@@ -5,7 +5,7 @@
 #ifndef BROWSER_DEVTOOLS_MANAGER_DELEGATE_H_
 #define BROWSER_DEVTOOLS_MANAGER_DELEGATE_H_
 
-#include "base/basictypes.h"
+#include "base/macros.h"
 #include "base/compiler_specific.h"
 #include "components/devtools_http_handler/devtools_http_handler_delegate.h"
 #include "content/public/browser/devtools_manager_delegate.h"

--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -573,7 +573,7 @@ void InspectableWebContentsImpl::AgentHostClosed(
     content::DevToolsAgentHost* agent_host, bool replaced) {
 }
 
-void InspectableWebContentsImpl::AboutToNavigateRenderFrame(
+void InspectableWebContentsImpl::RenderFrameHostChanged(
     content::RenderFrameHost* old_host,
     content::RenderFrameHost* new_host) {
   if (new_host->GetParent())
@@ -603,8 +603,9 @@ bool InspectableWebContentsImpl::AddMessageToConsole(
 
 bool InspectableWebContentsImpl::ShouldCreateWebContents(
     content::WebContents* web_contents,
-    int route_id,
-    int main_frame_route_id,
+    int32_t route_id,
+    int32_t main_frame_route_id,
+    int32_t main_frame_widget_route_id,
     WindowContainerType window_container_type,
     const std::string& frame_name,
     const GURL& target_url,

--- a/browser/inspectable_web_contents_impl.cc
+++ b/browser/inspectable_web_contents_impl.cc
@@ -592,9 +592,9 @@ void InspectableWebContentsImpl::WebContentsDestroyed() {
 
 bool InspectableWebContentsImpl::AddMessageToConsole(
     content::WebContents* source,
-    int32 level,
+    int32_t level,
     const base::string16& message,
-    int32 line_no,
+    int32_t line_no,
     const base::string16& source_id) {
   logging::LogMessage("CONSOLE", line_no, level).stream() << "\"" <<
       message << "\", source: " << source_id << " (" << line_no << ")";

--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -134,9 +134,9 @@ class InspectableWebContentsImpl :
 
   // content::WebContentsDelegate:
   bool AddMessageToConsole(content::WebContents* source,
-                           int32 level,
+                           int32_t level,
                            const base::string16& message,
-                           int32 line_no,
+                           int32_t line_no,
                            const base::string16& source_id) override;
   bool ShouldCreateWebContents(
       content::WebContents* web_contents,

--- a/browser/inspectable_web_contents_impl.h
+++ b/browser/inspectable_web_contents_impl.h
@@ -33,7 +33,6 @@ class InspectableWebContentsView;
 
 class InspectableWebContentsImpl :
     public InspectableWebContents,
-    public content::DevToolsFrontendHost::Delegate,
     public content::DevToolsAgentHostClient,
     public content::WebContentsObserver,
     public content::WebContentsDelegate,
@@ -117,8 +116,7 @@ class InspectableWebContentsImpl :
   void ClearPreferences() override;
 
   // content::DevToolsFrontendHostDelegate:
-  void HandleMessageFromDevToolsFrontend(const std::string& message) override;
-  void HandleMessageFromDevToolsFrontendToBackend(const std::string& message) override;
+  void HandleMessageFromDevToolsFrontend(const std::string& message);
 
   // content::DevToolsAgentHostClient:
   void DispatchProtocolMessage(content::DevToolsAgentHost* agent_host,
@@ -127,8 +125,8 @@ class InspectableWebContentsImpl :
                        bool replaced) override;
 
   // content::WebContentsObserver:
-  void AboutToNavigateRenderFrame(content::RenderFrameHost* old_host,
-                                  content::RenderFrameHost* new_host) override;
+  void RenderFrameHostChanged(content::RenderFrameHost* old_host,
+                              content::RenderFrameHost* new_host) override;
   void WebContentsDestroyed() override;
   void OnWebContentsFocused() override;
 
@@ -140,8 +138,9 @@ class InspectableWebContentsImpl :
                            const base::string16& source_id) override;
   bool ShouldCreateWebContents(
       content::WebContents* web_contents,
-      int route_id,
-      int main_frame_route_id,
+      int32_t route_id,
+      int32_t main_frame_route_id,
+      int32_t main_frame_widget_route_id,
       WindowContainerType window_container_type,
       const std::string& frame_name,
       const GURL& target_url,

--- a/browser/media/media_stream_devices_controller.cc
+++ b/browser/media/media_stream_devices_controller.cc
@@ -33,10 +33,10 @@ MediaStreamDevicesController::MediaStreamDevicesController(
       // and microphone to avoid popping two infobars.
       microphone_requested_(
           request.audio_type == content::MEDIA_DEVICE_AUDIO_CAPTURE ||
-          request.request_type == content::MEDIA_OPEN_DEVICE),
+          request.request_type == content::MEDIA_OPEN_DEVICE_PEPPER_ONLY),
       webcam_requested_(
           request.video_type == content::MEDIA_DEVICE_VIDEO_CAPTURE ||
-          request.request_type == content::MEDIA_OPEN_DEVICE) {
+          request.request_type == content::MEDIA_OPEN_DEVICE_PEPPER_ONLY) {
 }
 
 MediaStreamDevicesController::~MediaStreamDevicesController() {
@@ -72,7 +72,7 @@ void MediaStreamDevicesController::Accept() {
   content::MediaStreamDevices devices;
   if (microphone_requested_ || webcam_requested_) {
     switch (request_.request_type) {
-      case content::MEDIA_OPEN_DEVICE: {
+      case content::MEDIA_OPEN_DEVICE_PEPPER_ONLY: {
         const content::MediaStreamDevice* device = NULL;
         // For open device request pick the desired device or fall back to the
         // first available of the given type.

--- a/browser/net/devtools_network_interceptor.cc
+++ b/browser/net/devtools_network_interceptor.cc
@@ -207,7 +207,7 @@ void DevToolsNetworkInterceptor::ArmTimer(base::TimeTicks now) {
   base::TimeTicks desired_time =
       offset_ + tick_length_ * (last_tick_ + min_ticks_left);
 
-  int64_t min_baseline = std::numeric_limits<int64>::max();
+  int64_t min_baseline = std::numeric_limits<int64_t>::max();
   for (size_t i = 0; i < suspend_count; ++i) {
     if (suspended_transactions_[i].second < min_baseline)
       min_baseline = suspended_transactions_[i].second;

--- a/browser/net/devtools_network_transaction.cc
+++ b/browser/net/devtools_network_transaction.cc
@@ -106,10 +106,11 @@ int DevToolsNetworkTransaction::RestartIgnoringLastError(
 
 int DevToolsNetworkTransaction::RestartWithCertificate(
     net::X509Certificate* client_certificate,
+    net::SSLPrivateKey* client_private_key,
     const net::CompletionCallback& callback) {
   if (failed_)
     return net::ERR_INTERNET_DISCONNECTED;
-  int rv = transaction_->RestartWithCertificate(client_certificate, proxy_callback_);
+  int rv = transaction_->RestartWithCertificate(client_certificate, client_private_key, proxy_callback_);
   return SetupCallback(callback, rv, RESTART_WITH_CERTIFICATE);
 }
 
@@ -183,6 +184,11 @@ bool DevToolsNetworkTransaction::GetLoadTimingInfo(
 bool DevToolsNetworkTransaction::GetRemoteEndpoint(
     net::IPEndPoint* endpoint) const {
   return transaction_->GetRemoteEndpoint(endpoint);
+}
+
+void DevToolsNetworkTransaction::PopulateNetErrorDetails(
+    net::NetErrorDetails* details) const {
+  return transaction_->PopulateNetErrorDetails(details);
 }
 
 void DevToolsNetworkTransaction::SetPriority(net::RequestPriority priority) {

--- a/browser/net/devtools_network_transaction.h
+++ b/browser/net/devtools_network_transaction.h
@@ -46,6 +46,7 @@ class DevToolsNetworkTransaction : public net::HttpTransaction {
   int RestartIgnoringLastError(
       const net::CompletionCallback& callback) override;
   int RestartWithCertificate(net::X509Certificate* client_cert,
+                             net::SSLPrivateKey* client_private_key,
                              const net::CompletionCallback& callback) override;
   int RestartWithAuth(const net::AuthCredentials& credentials,
                       const net::CompletionCallback& callback) override;
@@ -65,6 +66,7 @@ class DevToolsNetworkTransaction : public net::HttpTransaction {
   void SetQuicServerInfo(net::QuicServerInfo* quic_server_info) override;
   bool GetLoadTimingInfo(net::LoadTimingInfo* load_timing_info) const override;
   bool GetRemoteEndpoint(net::IPEndPoint* endpoint) const override;
+  void PopulateNetErrorDetails(net::NetErrorDetails* details) const override;
   void SetPriority(net::RequestPriority priority) override;
   void SetWebSocketHandshakeStreamCreateHelper(
       net::WebSocketHandshakeStreamBase::CreateHelper* create_helper) override;

--- a/browser/network_delegate.cc
+++ b/browser/network_delegate.cc
@@ -92,14 +92,11 @@ void NetworkDelegate::OnBeforeRedirect(net::URLRequest* request,
 void NetworkDelegate::OnResponseStarted(net::URLRequest* request) {
 }
 
-void NetworkDelegate::OnURLRequestJobOrphaned(net::URLRequest* request) {
-}
-
-void NetworkDelegate::OnNetworkBytesReceived(const net::URLRequest& request,
+void NetworkDelegate::OnNetworkBytesReceived(net::URLRequest* request,
                                              int64_t bytes_read) {
 }
 
-void NetworkDelegate::OnNetworkBytesSent(const net::URLRequest& request,
+void NetworkDelegate::OnNetworkBytesSent(net::URLRequest* request,
                                          int64_t bytes_sent) {
 }
 
@@ -143,7 +140,11 @@ bool NetworkDelegate::OnCanEnablePrivacyMode(
   return false;
 }
 
-bool NetworkDelegate::OnFirstPartyOnlyCookieExperimentEnabled() const {
+bool OnAreStrictSecureCookiesEnabled() {
+  return true;
+}
+
+bool OnAreExperimentalCookieFeaturesEnabled() {
   return true;
 }
 

--- a/browser/network_delegate.h
+++ b/browser/network_delegate.h
@@ -43,10 +43,9 @@ class NetworkDelegate : public net::NetworkDelegate {
   void OnBeforeRedirect(net::URLRequest* request,
                         const GURL& new_location) override;
   void OnResponseStarted(net::URLRequest* request) override;
-  void OnURLRequestJobOrphaned(net::URLRequest* request) override;
-  void OnNetworkBytesReceived(const net::URLRequest& request,
+  void OnNetworkBytesReceived(net::URLRequest* request,
                               int64_t bytes_read) override;
-  void OnNetworkBytesSent(const net::URLRequest& request,
+  void OnNetworkBytesSent(net::URLRequest* request,
                           int64_t bytes_sent) override;
   void OnCompleted(net::URLRequest* request, bool started) override;
   void OnURLRequestDestroyed(net::URLRequest* request) override;
@@ -67,7 +66,9 @@ class NetworkDelegate : public net::NetworkDelegate {
   bool OnCanEnablePrivacyMode(
       const GURL& url,
       const GURL& first_party_for_cookies) const override;
-  bool OnFirstPartyOnlyCookieExperimentEnabled() const override;
+
+  virtual bool OnAreStrictSecureCookiesEnabled() const override;
+  virtual bool OnAreExperimentalCookieFeaturesEnabled() const override;
   bool OnCancelURLRequestWithPolicyViolatingReferrerHeader(
       const net::URLRequest& request,
       const GURL& target_url,

--- a/browser/permission_manager.cc
+++ b/browser/permission_manager.cc
@@ -32,6 +32,27 @@ int PermissionManager::RequestPermission(
   return kNoPendingOperation;
 }
 
+int PermissionManager::RequestPermissions(
+    const std::vector<content::PermissionType>& permissions,
+    content::RenderFrameHost* render_frame_host,
+    const GURL& requesting_origin,
+    bool user_gesture,
+    const base::Callback<void(
+        const std::vector<content::PermissionStatus>&)>& callback) {
+  std::vector<content::PermissionStatus> permissionStatuses;
+
+  for (auto permission : permissions) {
+    if (permission == content::PermissionType::MIDI_SYSEX) {
+      content::ChildProcessSecurityPolicy::GetInstance()->
+          GrantSendMidiSysExMessage(render_frame_host->GetProcess()->GetID());
+    }
+
+    permissionStatuses.push_back(content::PERMISSION_STATUS_GRANTED);
+  }
+
+  callback.Run(permissionStatuses);
+  return kNoPendingOperation;
+}
 void PermissionManager::CancelPermissionRequest(int request_id) {
 }
 

--- a/browser/permission_manager.h
+++ b/browser/permission_manager.h
@@ -23,6 +23,13 @@ class PermissionManager : public content::PermissionManager {
       const GURL& requesting_origin,
       bool user_gesture,
       const base::Callback<void(content::PermissionStatus)>& callback) override;
+  int RequestPermissions(
+      const std::vector<content::PermissionType>& permissions,
+      content::RenderFrameHost* render_frame_host,
+      const GURL& requesting_origin,
+      bool user_gesture,
+      const base::Callback<void(
+          const std::vector<content::PermissionStatus>&)>& callback) override;
   void CancelPermissionRequest(int request_id) override;
   void ResetPermission(content::PermissionType permission,
                        const GURL& requesting_origin,

--- a/browser/url_request_context_getter.cc
+++ b/browser/url_request_context_getter.cc
@@ -104,8 +104,16 @@ bool URLRequestContextGetter::DelegateURLSecurityManager::CanDelegate
   return delegate_->CanDelegateURLSecurity(auth_origin);
 }
 
+void URLRequestContextGetter::DelegateURLSecurityManager::SetDefaultWhitelist(
+  scoped_ptr<net::HttpAuthFilter> whitelist_default) {
+}
+
+void URLRequestContextGetter::DelegateURLSecurityManager::SetDelegateWhitelist(
+  scoped_ptr<net::HttpAuthFilter> whitelist_delegate) {
+}
+
 URLRequestContextGetter::Delegate::Delegate() :
-  orig_url_sec_mgr_(net::URLSecurityManager::Create(NULL, NULL)) {}
+  orig_url_sec_mgr_(net::URLSecurityManager::Create()) {}
 
 std::string URLRequestContextGetter::Delegate::GetUserAgent() {
   return base::EmptyString();

--- a/browser/url_request_context_getter.h
+++ b/browser/url_request_context_getter.h
@@ -59,6 +59,10 @@ class URLRequestContextGetter : public net::URLRequestContextGetter {
 
     bool CanUseDefaultCredentials(const GURL& auth_origin) const override;
     bool CanDelegate(const GURL& auth_origin) const override;
+    void SetDefaultWhitelist(
+      scoped_ptr<net::HttpAuthFilter> whitelist_default) override;
+    void SetDelegateWhitelist(
+      scoped_ptr<net::HttpAuthFilter> whitelist_delegate) override;
 
    private:
     URLRequestContextGetter::Delegate* delegate_;

--- a/browser/web_ui_controller_factory.h
+++ b/browser/web_ui_controller_factory.h
@@ -5,7 +5,7 @@
 #ifndef BRIGHTRAY_BROWSER_WEB_UI_CONTROLLER_FACTORY_H_
 #define BRIGHTRAY_BROWSER_WEB_UI_CONTROLLER_FACTORY_H_
 
-#include "base/basictypes.h"
+#include "base/macros.h"
 #include "content/public/browser/web_ui.h"
 #include "content/public/browser/web_ui_controller_factory.h"
 

--- a/browser/win/scoped_hstring.h
+++ b/browser/win/scoped_hstring.h
@@ -10,7 +10,7 @@
 #include <hstring.h>
 #include <windows.h>
 
-#include "base/basictypes.h"
+#include "base/macros.h"
 
 class ScopedHString {
  public:

--- a/browser/win/windows_toast_notification.cc
+++ b/browser/win/windows_toast_notification.cc
@@ -330,7 +330,7 @@ bool WindowsToastNotification::GetTextNodeList(
     ScopedHString* tag,
     IXmlDocument* doc,
     IXmlNodeList** node_list,
-    UINT32 req_length) {
+    Uint32_t req_length) {
   tag->Reset(L"text");
   if (!tag->success())
     return false;
@@ -338,7 +338,7 @@ bool WindowsToastNotification::GetTextNodeList(
   if (FAILED(doc->GetElementsByTagName(*tag, node_list)))
     return false;
 
-  UINT32 node_length;
+  Uint32_t node_length;
   if (FAILED((*node_list)->get_Length(&node_length)))
     return false;
 

--- a/browser/win/windows_toast_notification.cc
+++ b/browser/win/windows_toast_notification.cc
@@ -173,10 +173,10 @@ bool WindowsToastNotification::GetToastXml(
     if (!SetXmlText(*toast_xml, title, msg))
       return false;
   }
-  
+
   // Configure the toast's notification sound
   if (silent) {
-    if (FAILED(SetXmlAudioSilent(*toast_xml))) 
+    if (FAILED(SetXmlAudioSilent(*toast_xml)))
       return false;
   }
 
@@ -200,40 +200,40 @@ bool WindowsToastNotification::SetXmlAudioSilent(
   ComPtr<IXmlNode> root;
   if (FAILED(node_list->Item(0, &root)))
     return false;
-  
+
   ComPtr<IXmlElement> audio_element;
   ScopedHString audio_str(L"audio");
   if (FAILED(doc->CreateElement(audio_str, &audio_element)))
     return false;
-  
+
   ComPtr<IXmlNode> audio_node_tmp;
   if (FAILED(audio_element.As(&audio_node_tmp)))
     return false;
-  
+
   // Append audio node to toast xml
   ComPtr<IXmlNode> audio_node;
   if (FAILED(root->AppendChild(audio_node_tmp.Get(), &audio_node)))
     return false;
-  
+
   // Create silent attribute
   ComPtr<IXmlNamedNodeMap> attributes;
   if (FAILED(audio_node->get_Attributes(&attributes)))
     return false;
-    
+
   ComPtr<IXmlAttribute> silent_attribute;
   ScopedHString silent_str(L"silent");
   if (FAILED(doc->CreateAttribute(silent_str, &silent_attribute)))
     return false;
-  
+
   ComPtr<IXmlNode> silent_attribute_node;
   if (FAILED(silent_attribute.As(&silent_attribute_node)))
     return false;
-  
+
   // Set silent attribute to true
   ScopedHString silent_value(L"true");
   if (!silent_value.success())
     return false;
-  
+
   ComPtr<IXmlText> silent_text;
   if (FAILED(doc->CreateTextNode(silent_value, &silent_text)))
     return false;
@@ -241,11 +241,11 @@ bool WindowsToastNotification::SetXmlAudioSilent(
   ComPtr<IXmlNode> silent_node;
   if (FAILED(silent_text.As(&silent_node)))
     return false;
-    
+
   ComPtr<IXmlNode> child_node;
   if (FAILED(silent_attribute_node->AppendChild(silent_node.Get(), &child_node)))
     return false;
-  
+
   ComPtr<IXmlNode> silent_attribute_pnode;
   return SUCCEEDED(attributes.Get()->SetNamedItem(silent_attribute_node.Get(), &silent_attribute_pnode));
 }
@@ -330,7 +330,7 @@ bool WindowsToastNotification::GetTextNodeList(
     ScopedHString* tag,
     IXmlDocument* doc,
     IXmlNodeList** node_list,
-    Uint32_t req_length) {
+    uint32_t req_length) {
   tag->Reset(L"text");
   if (!tag->success())
     return false;
@@ -338,7 +338,7 @@ bool WindowsToastNotification::GetTextNodeList(
   if (FAILED(doc->GetElementsByTagName(*tag, node_list)))
     return false;
 
-  Uint32_t node_length;
+  uint32_t node_length;
   if (FAILED((*node_list)->get_Length(&node_length)))
     return false;
 

--- a/browser/win/windows_toast_notification.h
+++ b/browser/win/windows_toast_notification.h
@@ -70,7 +70,7 @@ class WindowsToastNotification : public Notification {
   bool GetTextNodeList(ScopedHString* tag,
                        ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                        ABI::Windows::Data::Xml::Dom::IXmlNodeList** nodeList,
-                       Uint32_t reqLength);
+                       uint32_t reqLength);
   bool AppendTextToXml(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                        ABI::Windows::Data::Xml::Dom::IXmlNode* node,
                        const std::wstring& text);

--- a/browser/win/windows_toast_notification.h
+++ b/browser/win/windows_toast_notification.h
@@ -70,7 +70,7 @@ class WindowsToastNotification : public Notification {
   bool GetTextNodeList(ScopedHString* tag,
                        ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                        ABI::Windows::Data::Xml::Dom::IXmlNodeList** nodeList,
-                       UINT32 reqLength);
+                       Uint32_t reqLength);
   bool AppendTextToXml(ABI::Windows::Data::Xml::Dom::IXmlDocument* doc,
                        ABI::Windows::Data::Xml::Dom::IXmlNode* node,
                        const std::wstring& text);


### PR DESCRIPTION
## TODO:

- [ ] Update HttpAuthHandlerRegistryFactory call to use new HttpAuthPreferences class
- [ ] InspectableWebContentsImpl now uses a callback instead of a delegate to forward DevTools messages

/cc #200 
