### PR TITLE
[Windows] Notify only when enabled

### DIFF
--- a/browser/win/windows_toast_notification.cc
+++ b/browser/win/windows_toast_notification.cc
@@ -89,7 +89,16 @@ void WindowsToastNotification::Show(
     const bool silent) {
   auto presenter_win = static_cast<NotificationPresenterWin*>(presenter());
   std::wstring icon_path = presenter_win->SaveIconToFilesystem(icon, icon_url);
-
+  
+  // Ask Windows for the current notification settings
+  // If not allowed, we return here (0 = enabled)
+  ABI::Windows::UI::Notifications::NotificationSetting setting;
+  toast_notifier_->get_Setting(&setting);
+  if (setting != 0) {
+    NotificationFailed();
+    return;
+  }
+  
   ComPtr<IXmlDocument> toast_xml;
   if(FAILED(GetToastXml(toast_manager_.Get(), title, msg, icon_path, silent, &toast_xml))) {
     NotificationFailed();


### PR DESCRIPTION
- Previously, we'd attempt to create a notification no matter what the
  user's configuration was. Microsoft advises against that, because it
  can create race conditions if notifications are disabled.
- This fixes the issue.

Closes https://github.com/atom/electron/issues/4681